### PR TITLE
feat: MSW로 회원가입 mock API 구현

### DIFF
--- a/src/components/signin/SignInForm.tsx
+++ b/src/components/signin/SignInForm.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import { FormEvent, useState } from 'react';
 import { SiNaver } from 'react-icons/si';
+import { FaRegEye, FaRegEyeSlash } from 'react-icons/fa';
 import { RiKakaoTalkFill } from 'react-icons/ri';
 
 const SingInPage = () => {
@@ -10,8 +11,13 @@ const SingInPage = () => {
   const [password, setPassword] = useState('');
 
   const [error, setError] = useState('');
+  const [passwordVisible, setPasswordVisible] = useState(false);
 
   const router = useRouter();
+
+  const togglePasswordVisibility = () => {
+    setPasswordVisible(!passwordVisible);
+  };
 
   const handleSignInSubmit = async (e: FormEvent<HTMLFormElement>) => {
     try {
@@ -88,14 +94,27 @@ const SingInPage = () => {
           <label htmlFor="password" className="block mb-2 font-semibold">
             비밀번호
           </label>
-          <input
-            id="password"
-            type="password"
-            value={password}
-            onChange={e => setPassword(e.target.value)}
-            placeholder="비밀번호를 입력해 주세요."
-            className="w-full px-4 py-2 rounded border bg-white focus:outline-indigo-500"
-          />
+          <div className="relative">
+            <input
+              id="password"
+              type={passwordVisible ? 'text' : 'password'}
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="비밀번호를 입력해 주세요."
+              className="w-full px-4 py-2 rounded border bg-white focus:outline-indigo-500"
+            />
+            <button
+              type="button"
+              onClick={togglePasswordVisibility}
+              className="absolute right-2 top-1/2 transform -translate-y-1/2"
+            >
+              {passwordVisible ? (
+                <FaRegEye size={20} />
+              ) : (
+                <FaRegEyeSlash size={20} />
+              )}
+            </button>
+          </div>
         </div>
         {error && <p className="text-red-500 mt-2">{error}</p>}
         <button

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,11 @@
 import { studyHandlers } from './study';
 import { qnaHandlers } from './qna';
 import { infoHandlers } from './info';
+import { signUpHandlers } from './signup';
 
-export const handlers = [...studyHandlers, ...qnaHandlers, ...infoHandlers];
+export const handlers = [
+  ...studyHandlers,
+  ...qnaHandlers,
+  ...infoHandlers,
+  ...signUpHandlers,
+];

--- a/src/mocks/handlers/signup.ts
+++ b/src/mocks/handlers/signup.ts
@@ -1,0 +1,159 @@
+import { rest } from 'msw';
+
+export const signUpHandlers = [
+  // 이메일 중복 확인
+  rest.post('/api/auth/check-email', async (req, res, ctx) => {
+    const { email } = await req.json();
+    if (!email || !email.trim()) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'INVALID_EMAIL',
+          message: '이메일을 입력해 주세요.',
+        }),
+      );
+    }
+
+    if (email === 'test@example.com') {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'EMAIL_ALREADY_REGISTERED',
+          message: '이미 사용 중인 이메일입니다.',
+        }),
+      );
+    }
+    return res(
+      ctx.status(200),
+      ctx.json({ message: '사용 가능한 이메일입니다.' }),
+    );
+  }),
+
+  // 인증번호 메일 발송
+  rest.post('/api/auth/email-auth', async (req, res, ctx) => {
+    const { email } = await req.json();
+    if (!email || !email.trim()) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'INVALID_EMAIL',
+          message: '이메일을 입력해주세요.',
+        }),
+      );
+    }
+
+    // 인증번호 임의로 생성
+    const authCode = '123456';
+
+    console.log(`이메일로 인증 코드 발송: ${authCode} (${email})`);
+
+    return res(
+      ctx.status(200),
+      ctx.json({ message: '인증번호가 발송되었습니다.' }),
+    );
+  }),
+
+  // 인증번호 확인
+  rest.post('/api/auth/email-auth/code', async (req, res, ctx) => {
+    const { email, code } = await req.json();
+    if (!code) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'INVALID_CODE',
+          message: '인증 코드를 입력해주세요.',
+        }),
+      );
+    }
+    if (code !== '123456') {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'VALIDATION_FAILED',
+          message: '인증 코드가 일치하지 않습니다.',
+        }),
+      );
+    }
+    return res(
+      ctx.status(200),
+      ctx.json({
+        message: '인증되었습니다!',
+      }),
+    );
+  }),
+
+  // 닉네임 중복 확인
+  rest.post('/api/auth/check-nickname', async (req, res, ctx) => {
+    const { nickName } = await req.json();
+
+    if (!nickName || !nickName.trim()) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'INVALID_NICKNAME',
+          message: '닉네임을 입력해주세요.',
+        }),
+      );
+    }
+
+    if (nickName === 'testNickName') {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'NICKNAME_ALREADY_REGISTERED',
+          message: '이미 사용 중인 닉네임입니다.',
+        }),
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({ message: '사용 가능한 닉네임입니다.' }),
+    );
+  }),
+
+  // 회원가입 폼 제출
+  rest.post('/api/auth/sign-up', async (req, res, ctx) => {
+    const { email, password, nickName } = await req.json();
+
+    if (!email || !email.trim()) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'INVALID_EMAIL',
+          message: '이메일을 입력하세요.',
+        }),
+      );
+    }
+
+    if (
+      !password ||
+      password.length < 8 ||
+      !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])/.test(password)
+    ) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'INVALID_PASSWORD',
+          message:
+            '비밀번호는 최소 8자 이상이며, 하나 이상의 영문자, 숫자, 특수문자가 포함되어야 합니다.',
+        }),
+      );
+    }
+
+    if (!nickName || !nickName.trim()) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          errorCode: 'INVALID_NICKNAME',
+          message: '닉네임을 입력하세요.',
+        }),
+      );
+    }
+
+    return res(
+      ctx.status(201),
+      ctx.json({ message: '회원가입이 성공적으로 완료되었습니다!' }),
+    );
+  }),
+];


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 회원가입
  - 회원가입 mock API 구현되지 않음
  -API URL이 환경변수로 처리되지 않음
  - 인증코드 확인 성공 시, `alert`창으로 인증 성공 메시지 띄움
  - 비밀번호 확인이 일치하여도 일치했다는 메시지 보여주지 않음
  - 비밀번호 보기/숨기기 토글 기능 구현되지 않음
- 로그인
  - 비밀번호 보기/숨기기 토글 기능 구현되지 않음

**TO-BE**
- 회원가입
  - 회원가입 mock API 구현
  -API URL을 환경변수로 처리하여 보안 강화
  - 인증 코드 메시지 및 비밀번호 확인 메시지 성공/실패에 따라 초록색/빨간색으로 구분하여 처리
  - 비밀번호 보기/숨기기 토글 기능 구현
- 로그인
  - 비밀번호 보기/숨기기 토글 기능 구현

### 테스트
- [X] 회원가입 mock API 테스트
- [X] 비밀번호 보기/숨기기 기능 테스트

### ️📸 스크린샷
<img width="401" alt="image" src="https://github.com/user-attachments/assets/b937c867-9e60-4512-a544-b1952d3c522a">

