### PR TITLE
feat: Next.js API Routes로 로그인 mock API 구현

### DIFF
--- a/src/app/api/auth/status/route.ts
+++ b/src/app/api/auth/status/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import jwt from 'jsonwebtoken';
+import axios from 'axios';
+
+export const GET = async (req: Request) => {
+  const cookies = req.headers.get('cookie');
+
+  const accessToken = cookies?.match(/accessToken=([^;]+)/)?.[1];
+  if (!accessToken) {
+    return NextResponse.json({ isSignedIn: false }, { status: 401 });
+  }
+
+  try {
+    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!);
+
+    const response = await axios.get(
+      `${process.env.API_BASE_URL}/auth/status`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    return NextResponse.json({
+      isSignedIn: true,
+      user: response.data.user,
+    });
+  } catch (error) {
+    return NextResponse.json({ isSignedIn: false }, { status: 401 });
+  }
+};

--- a/src/app/api/mock/auth/refresh/route.ts
+++ b/src/app/api/mock/auth/refresh/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import jwt from 'jsonwebtoken';
+
+export const POST = async (req: NextRequest) => {
+  const cookiesList = await cookies();
+  const refreshToken = cookiesList.get('refreshToken')?.value;
+
+  if (!refreshToken) {
+    return NextResponse.json(
+      { message: '리프레시 토큰이 없습니다.' },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const decoded = jwt.verify(
+      refreshToken,
+      `${process.env.REFRESH_TOKEN_SECRET}`,
+    ) as { email: string };
+    const newAccessToken = jwt.sign(
+      { email: decoded.email },
+      `${process.env.ACCESS_TOKEN_SECRET}`,
+      { expiresIn: '15m' },
+    );
+    const decodedAccessToken = jwt.decode(newAccessToken) as { exp: number };
+    const currentTime = Math.trunc(Date.now() / 1000);
+    const accessTokenMaxAge = decodedAccessToken.exp - currentTime;
+
+    const res = NextResponse.json({ message: '토큰 갱신 성공' });
+
+    const cookies = res.cookies;
+    cookies.set('accessToken', newAccessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      sameSite: 'strict',
+      maxAge: accessTokenMaxAge,
+    });
+
+    return res;
+  } catch (error) {
+    return NextResponse.json(
+      {
+        message: '리프레시 토큰이 유효하지 않거나 만료되었습니다.',
+      },
+      { status: 401 },
+    );
+  }
+};

--- a/src/app/api/mock/auth/signin/route.ts
+++ b/src/app/api/mock/auth/signin/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import jwt from 'jsonwebtoken';
+
+export const POST = async (req: NextRequest) => {
+  const { email, password } = await req.json();
+
+  if (email === 'test@example.com' && password === 'test1234!!') {
+    // mock 엑세스 토큰과 리프레시 토큰 생성
+    const accessToken = jwt.sign(
+      { email },
+      `${process.env.ACCESS_TOKEN_SECRET}`,
+      { expiresIn: '15m' },
+    );
+    const refreshToken = jwt.sign(
+      { email },
+      `${process.env.REFRESH_TOKEN_SECRET}`,
+      { expiresIn: '3d' },
+    );
+
+    const decodedAccessToken = jwt.decode(accessToken) as { exp: number };
+    const currentTime = Math.trunc(Date.now() / 1000);
+    const accessTokenMaxAge = decodedAccessToken.exp - currentTime;
+
+    const decodeRefreshToken = jwt.decode(refreshToken) as { exp: number };
+    const refreshTokenMaxAge = decodeRefreshToken.exp - currentTime;
+
+    const res = NextResponse.json({ message: '로그인 성공' });
+
+    const cookies = res.cookies;
+    cookies.set('accessToken', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      sameSite: 'strict',
+      maxAge: accessTokenMaxAge,
+    });
+
+    cookies.set('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      sameSite: 'strict',
+      maxAge: refreshTokenMaxAge,
+    });
+
+    return res;
+  }
+
+  return NextResponse.json(
+    {
+      message:
+        '이메일 혹은 비밀번호가 일치하지 않습니다. 입력한 내용을 다시 확인해 주세요.',
+    },
+    { status: 401 },
+  );
+};

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import Link from 'next/link';
+import { useAuthStore } from '@/store/authStore';
 import { usePathname } from 'next/navigation';
 
-export default function Header() {
+const Header = () => {
+  const { isSignedIn, signout } = useAuthStore();
+
   const pathname = usePathname();
 
   const isActive = (path: string) => {
@@ -52,16 +55,28 @@ export default function Header() {
         </div>
       </div>
       <div className="navbar-end">
-        <Link href="/mypage/1" className="btn btn-ghost text-white">
-          마이페이지
-        </Link>
-        <Link href="/signin" className="btn btn-ghost text-white">
-          로그인
-        </Link>
-        <Link href="/signup" className="btn btn-ghost text-white">
-          회원가입
-        </Link>
+        {isSignedIn ? (
+          <>
+            <Link href="/mypage/1" className="btn btn-ghost text-white">
+              마이페이지
+            </Link>
+            <button onClick={signout} className="btn btn-ghost text-white">
+              로그아웃
+            </button>
+          </>
+        ) : (
+          <>
+            <Link href="/signin" className="btn btn-ghost text-white">
+              로그인
+            </Link>
+            <Link href="/signup" className="btn btn-ghost text-white">
+              회원가입
+            </Link>
+          </>
+        )}
       </div>
     </header>
   );
-}
+};
+
+export default Header;

--- a/src/components/signin/SignInForm.tsx
+++ b/src/components/signin/SignInForm.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useAuthStore } from '@/store/authStore';
 import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import { FormEvent, useState } from 'react';
@@ -14,6 +15,7 @@ const SingInPage = () => {
   const [passwordVisible, setPasswordVisible] = useState(false);
 
   const router = useRouter();
+  const { signin } = useAuthStore();
 
   const togglePasswordVisibility = () => {
     setPasswordVisible(!passwordVisible);
@@ -31,7 +33,7 @@ const SingInPage = () => {
       }
 
       const response = await axios.post(
-        `${process.env.NEXT_PUBLIC_API_URL}/auth/signin`, // Next.js API Route로 수정
+        `${process.env.NEXT_PUBLIC_API_URL}/mock/auth/signin`, // Next.js API Route로 수정
         {
           email,
           password,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  isSignedIn: boolean;
+  signin: (accessToekn: string, refreshToken: string) => void;
+  signout: () => void;
+}
+
+export const useAuthStore = create<AuthState>(set => ({
+  accessToken: null,
+  refreshToken: null,
+  isSignedIn: false,
+  signin: (accessToken: string, refreshToken: string) => {
+    set({ accessToken, refreshToken, isSignedIn: true });
+  },
+  signout: () => {
+    set({ accessToken: null, refreshToken: null, isSignedIn: false });
+  },
+}));

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,18 @@
+import jwt from 'jsonwebtoken';
+
+export async function getAuthStatus(cookies: string | null) {
+  if (!cookies) return false; // 쿠키가 없으면 로그인하지 않은 상태
+
+  // 쿠키에서 accessToken을 추출
+  const accessToken = cookies.match(/accessToken=([^;]+)/)?.[1];
+
+  if (!accessToken) return false; // 액세스토큰이 없으면 로그인하지 않은 상태
+
+  try {
+    // JWT 검증 (JWT_SECRET은 환경변수에 저장)
+    jwt.verify(accessToken, process.env.JWT_SECRET!);
+    return true; // 인증된 사용자
+  } catch (error) {
+    return false; // 인증 실패
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 로그인
  - 로그인 mock API 구현되지 않음
  - 유저의 로그인 상태를 확인하는 함수 구현되지 않음
- 헤더 컴포넌트
  - 로그인 상태 구분없이 구현 

**TO-BE**
- 로그인
  - 로그인 mock API 구현
  - 인증 상태 확인하는 API 및 유틸리티 함수 추가
  - zustand를 사용하여 인증 상태 관리 구현
    - **협의 필요:** zustand 상태 관리 방법에 대한 협의 필요
- 헤더 컴포넌트
  - 로그인 상태가 true일 때, 마이페이지 및 로그아웃을 표시하고, 로그인 상태가 false일 때 로그인 및 회원가입을 표시하도록 UI 수정
### 테스트
- [X] 로그인 mock API 테스트
- [ ] 헤더 컴포넌트 UI 로그인 상태에 따라 변경 확인 필요
