### PR TITLE
feat: 회원정보 조회 기능 구현 및 회원정보 전역 상태 관리 개선

### DIFF
--- a/src/app/api/mock/auth/signin/route.ts
+++ b/src/app/api/mock/auth/signin/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
 
+const mockUserData = {
+  id: 1,
+  email: 'test@example.com',
+  nickname: 'testuser',
+  profileImageUrl: 'https://via.placeholder.com/150',
+};
+
 export const POST = async (req: NextRequest) => {
   const { email, password } = await req.json();
 
-  if (email === 'test@example.com' && password === 'test1234!!') {
+  if (email === mockUserData.email && password === 'test1234!!') {
     // mock 엑세스 토큰과 리프레시 토큰 생성
     const accessToken = jwt.sign(
       { email },
@@ -24,7 +31,15 @@ export const POST = async (req: NextRequest) => {
     const decodeRefreshToken = jwt.decode(refreshToken) as { exp: number };
     const refreshTokenMaxAge = decodeRefreshToken.exp - currentTime;
 
-    const res = NextResponse.json({ message: '로그인 성공' });
+    const res = NextResponse.json({
+      message: '로그인 성공',
+      userInfo: {
+        id: mockUserData.id,
+        nickname: mockUserData.nickname,
+        email: mockUserData.email,
+        profileImageUrl: mockUserData.profileImageUrl,
+      },
+    });
 
     const cookies = res.cookies;
     cookies.set('accessToken', accessToken, {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,6 @@ import Footer from '@/components/layout/Footer';
 import { MSWProvider } from '@/mocks/compoenets/MSWProvider';
 import './globals.css';
 import { cookies } from 'next/headers';
-import { getAuthStatus } from '@/utils/auth';
-import { useAuthStore } from '@/store/authStore';
 
 export const metadata: Metadata = {
   title: 'DevOnOff',

--- a/src/app/mypage/[userId]/page.tsx
+++ b/src/app/mypage/[userId]/page.tsx
@@ -1,55 +1,50 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
 import axios from 'axios';
+import { cookies } from 'next/headers';
+import MyPageView from '../components/myPageView';
+// const fetchStudies = async (accessToken: string) => {
+//   const response = await axios.get(
+//     `${process.env.NEXT_PUBLIC_API_URL}/studies`,
+//     {
+//       headers: {
+//         Authorization: `Bearer ${accessToken}`,
+//       },
+//     },
+//   );
+//   return response.data;
+// };
 
 const studies = [
   { id: '1', name: '알고리즘 스터디' },
   { id: '2', name: '웹 개발 스터디' },
 ];
 
-const MyPage = () => {
-  const router = useRouter();
-  const [, setIsLoading] = useState(false);
+const MyPage = async () => {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
 
-  const handleChatRoomOpen = async (studyId: string) => {
-    setIsLoading(true);
+  if (!accessToken) {
+    return (
+      <div>
+        <h1>로그인이 필요합니다.</h1>
+        <a href="/signin" className="btn btn-primary">
+          로그인하러 가기
+        </a>
+      </div>
+    );
+  }
 
-    try {
-      const userId = '1';
-      const response = await axios.post(
-        `${process.env.NEXT_PUBLIC_BACKEND_SOCKET_URL}/chat-room/${studyId}/user/${userId}`,
-      );
-      const { chatRoomId } = response.data;
-      if (chatRoomId) {
-        router.push(`/chat/${chatRoomId}`);
-      }
-    } catch (error) {
-      console.error('Failed to open chat room:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">마이페이지</h1>
-      <ul className="space-y-2">
-        {studies.map(study => (
-          <li key={study.id} className="flex items-center justify-between">
-            <span>{study.name}</span>
-            <button
-              onClick={() => handleChatRoomOpen(study.id)}
-              className="btn btn-primary"
-            >
-              채팅방 열기
-            </button>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+  try {
+    // const studies = await fetchStudies(accessToken);
+    return <MyPageView studies={studies} />;
+  } catch (error) {
+    console.error('내가 속한 스터디 목록 가져오기 실패');
+    return (
+      <>
+        <h1>데이터 로딩 실패</h1>
+        <p>잠시 후 다시 시도해주세요.</p>
+      </>
+    );
+  }
 };
 
 export default MyPage;

--- a/src/app/mypage/components/myPageView.tsx
+++ b/src/app/mypage/components/myPageView.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import axios from 'axios';
+import { useAuthStore } from '@/store/authStore';
+
+interface Study {
+  id: string;
+  name: string;
+}
+
+interface MyPageProps {
+  studies: Study[];
+}
+
+const MyPageView = ({ studies }: MyPageProps) => {
+  const router = useRouter();
+  const [, setIsLoading] = useState(false);
+  const { isSignedIn, setIsSignedIn } = useAuthStore();
+
+  const handleChatRoomOpen = async (studyId: string) => {
+    setIsLoading(true);
+
+    try {
+      const userId = '1';
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BACKEND_SOCKET_URL}/chat-room/${studyId}/user/${userId}`,
+      );
+      const { chatRoomId } = response.data;
+      if (chatRoomId) {
+        router.push(`/chat/${chatRoomId}`);
+      }
+    } catch (error) {
+      console.error('Failed to open chat room:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">마이페이지</h1>
+      <ul className="space-y-2">
+        {studies.map(study => (
+          <li key={study.id} className="flex items-center justify-between">
+            <span>{study.name}</span>
+            <button
+              onClick={() => handleChatRoomOpen(study.id)}
+              className="btn btn-primary"
+            >
+              채팅방 열기
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MyPageView;

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -11,15 +11,30 @@ type HeaderProps = {
   initialSignedIn: boolean;
 };
 const Header = ({ initialSignedIn }: HeaderProps) => {
-  const { isSignedIn, setIsSignedIn } = useAuthStore();
+  const { isSignedIn, setIsSignedIn, setUserInfo, userInfo } = useAuthStore();
 
   const pathname = usePathname();
   const router = useRouter();
-
   // 초기 로그인 상태를 클라이언트 상태로 설정
   useEffect(() => {
     setIsSignedIn(initialSignedIn);
-  }, [initialSignedIn, setIsSignedIn]);
+
+    // if (initialSignedIn) {
+    //   const mockUserInfo = {
+    //     id: 1,
+    //     nickname: 'testuser',
+    //     email: 'test@example.com',
+    //     profileImageUrl: 'https://via.placeholder.com/150',
+    //   };
+    //   setUserInfo(mockUserInfo);
+    // } else {
+    //   setUserInfo(null);
+    // }
+  }, [initialSignedIn, setIsSignedIn, setUserInfo]);
+
+  useEffect(() => {
+    console.log(`userInfo는: ${userInfo?.id}`);
+  }, [userInfo]);
 
   const isActive = (path: string) => {
     return pathname === path ? 'btn-active' : '';

--- a/src/components/signin/SignInForm.tsx
+++ b/src/components/signin/SignInForm.tsx
@@ -14,7 +14,7 @@ const SingInPage = () => {
   const [error, setError] = useState('');
   const [passwordVisible, setPasswordVisible] = useState(false);
 
-  const { setIsSignedIn } = useAuthStore();
+  const { setIsSignedIn, setUserInfo } = useAuthStore();
   const router = useRouter();
 
   const togglePasswordVisibility = () => {
@@ -44,8 +44,13 @@ const SingInPage = () => {
         },
       );
 
-      if (response.status === 200) {
+      if (response.status === 200 && response.data.userInfo) {
         setIsSignedIn(true);
+        setUserInfo(response.data.userInfo); // 실제로는 Next.js API Route에서 처리 예정
+
+        console.log('현재 사용자 정보: ', response.data.userInfo);
+        console.log('현재 로그인 상태: ', true);
+
         router.push('/community/study');
       }
     } catch (error: any) {
@@ -87,6 +92,7 @@ const SingInPage = () => {
               placeholder="이메일을 입력해 주세요."
               onChange={e => {
                 setEmail(e.target.value);
+                setError('');
               }}
               className="flex-grow px-4 py-2 rounded border bg-white focus:outline-indigo-500"
             />
@@ -102,7 +108,10 @@ const SingInPage = () => {
               id="password"
               type={passwordVisible ? 'text' : 'password'}
               value={password}
-              onChange={e => setPassword(e.target.value)}
+              onChange={e => {
+                setPassword(e.target.value);
+                setError('');
+              }}
               placeholder="비밀번호를 입력해 주세요."
               className="w-full px-4 py-2 rounded border bg-white focus:outline-indigo-500"
             />
@@ -137,7 +146,7 @@ const SingInPage = () => {
         </button>
         <button
           name="Kakao"
-          className="mt-4 flex items-center justify-center w-full px-4 py-2 text-yellow-950 bg-yellow-300 border border-gray-300 rounded-md hover:bg-yellow-400 hover:"
+          className="mt-4 flex items-center justify-center w-full px-4 py-2 text-yellow-950 bg-yellow-300 border border-gray-300 rounded-md hover:bg-yellow-400"
         >
           <RiKakaoTalkFill className="mr-2 text-yellow-950" size={24} />
           <span className="font-medium">Kakao</span> 로그인

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+
 type UserInfo = {
   id: number;
   nickname: string;
@@ -10,7 +11,7 @@ type AuthState = {
   isSignedIn: boolean;
   setIsSignedIn: (status: boolean) => void;
   userInfo: UserInfo | null;
-  setUserInfo: (info: UserInfo) => void;
+  setUserInfo: (info: UserInfo | null) => void;
 };
 
 export const useAuthStore = create<AuthState>(set => ({

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,18 +1,32 @@
-import jwt from 'jsonwebtoken';
+import axios from 'axios';
+// import { cookies } from 'next/headers';
 
-export async function getAuthStatus(cookies: string | null) {
-  if (!cookies) return false; // 쿠키가 없으면 로그인하지 않은 상태
-
-  // 쿠키에서 accessToken을 추출
-  const accessToken = cookies.match(/accessToken=([^;]+)/)?.[1];
-
-  if (!accessToken) return false; // 액세스토큰이 없으면 로그인하지 않은 상태
-
+export const reissueAccessToken = async (email: string) => {
   try {
-    // JWT 검증 (JWT_SECRET은 환경변수에 저장)
-    jwt.verify(accessToken, process.env.JWT_SECRET!);
-    return true; // 인증된 사용자
+    const response = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/mock/auth/refresh`,
+      { email },
+    );
+
+    if (response.status === 200) {
+      const { accessToken } = response.data;
+      return accessToken;
+    } else {
+      throw new Error('액세스 토큰 재발급 실패');
+    }
   } catch (error) {
-    return false; // 인증 실패
+    console.error('액세스 토큰 재발급 실패:', error);
+    throw new Error('엑세스 토큰 재발급 실패');
   }
-}
+};
+
+// export const getAccessToken = async () => {
+//   const cookieStore = await cookies();
+//   const accessToken = cookieStore.get('accessToken')?.value;
+
+//   if (!accessToken) {
+//     throw new Error('Access token is missing');
+//   }
+
+//   return accessToken;
+// };


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 로그인 후 회원 정보를 요청하는 기능이 구현되지 않음
- 액세스 토큰 재발급 기능 구현되지 않음
- 회원 정보 조회를 위한 mock API 구현되지 않음

**TO-BE**
- 로그인 & 회원정보 조회
  - 로그인 성공 시, 인증 헤더에 토큰을 포함하여 Next.js API Route에서 백엔드에 회원 정보를 요청
  - 백엔드에서 받아온 유저 정보를 zustand로 관리
  - 액세스토큰 재발급 함수 구현
  - 회원정보 조회 mock api 구현
- 마이페이지
  - 서버컴포넌트에서 쿠키에 저장된 토큰값을 가져온 다음, 토큰값으로 로그인 상태 구분
  - 상태에 따라 마이페이지를 다르게 렌더링
 

### 테스트
- [X] 회원정보 조회 mock API 테스트 완료