### PR TITLE
feat: 미들웨어를 통한 인증 헤더 토큰 설정 및 마이페이지 회원 정보 UI 구현

### DIFF
--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -3,16 +3,15 @@ import axios from 'axios';
 import { cookies } from 'next/headers';
 
 export const POST = async (req: NextRequest) => {
-  // 쿠키에서 액세스토큰과 리프레시토큰을 삭제
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
+  // 요청 헤더 AxiosHeaders 형식으로 변환
+  const headers = Object.fromEntries(req.headers.entries());
 
-  if (!accessToken) {
-    return NextResponse.json(
-      { message: '이미 로그아웃 상태입니다.' },
-      { status: 400 },
-    );
-  }
+  // if (!accessToken) {
+  //   return NextResponse.json(
+  //     { message: '이미 로그아웃 상태입니다.' },
+  //     { status: 400 },
+  //   );
+  // }
   const res = NextResponse.json({ message: '로그아웃 성공' });
 
   try {
@@ -20,10 +19,11 @@ export const POST = async (req: NextRequest) => {
       `${process.env.API_BASE_URL}/auth/sign-out`, // 실제 백엔드 API 경로
       {},
       {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${accessToken}`,
-        },
+        headers,
+        // : {
+        //   'Content-Type': 'application/json',
+        //   Authorization: `Bearer ${accessToken}`,
+        // },
       },
     );
     const res = NextResponse.json({ message: '로그아웃 성공' });
@@ -39,8 +39,6 @@ export const POST = async (req: NextRequest) => {
   } catch (error) {
     return NextResponse.json({ message: '로그아웃 실패' }, { status: 500 });
   }
-
-  // 쿠키에서 액세스토큰과 리프레시토큰을 삭제
 
   return res;
 };

--- a/src/app/api/mock/auth/signout/route.ts
+++ b/src/app/api/mock/auth/signout/route.ts
@@ -7,6 +7,10 @@ export const POST = async () => {
     path: '/',
     maxAge: 0,
   });
+  response.cookies.set('refreshToken', '', {
+    path: '/',
+    maxAge: 0, // 쿠키 삭제
+  });
 
   return response;
 };

--- a/src/app/mypage/[userId]/page.tsx
+++ b/src/app/mypage/[userId]/page.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { cookies } from 'next/headers';
-import MyPageView from '../components/myPageView';
+import MyPageView from '../components/MyPageView';
+import UserInfoView from '../components/UserInfoView';
 // const fetchStudies = async (accessToken: string) => {
 //   const response = await axios.get(
 //     `${process.env.NEXT_PUBLIC_API_URL}/studies`,
@@ -35,7 +36,12 @@ const MyPage = async () => {
 
   try {
     // const studies = await fetchStudies(accessToken);
-    return <MyPageView studies={studies} />;
+    return (
+      <>
+        <UserInfoView />
+        <MyPageView studies={studies} />
+      </>
+    );
   } catch (error) {
     console.error('내가 속한 스터디 목록 가져오기 실패');
     return (

--- a/src/app/mypage/components/UserInfoView.tsx
+++ b/src/app/mypage/components/UserInfoView.tsx
@@ -1,0 +1,90 @@
+'use client';
+import { useState } from 'react';
+import { useAuthStore } from '@/store/authStore';
+
+const UserInfoView = () => {
+  const { userInfo, setUserInfo } = useAuthStore(); // zustand에서 회원정보 가져오기
+  const [nickname, setNickname] = useState(userInfo?.nickname || '');
+  const [email, setEmail] = useState(userInfo?.email || '');
+  const [profileImageUrl, setProfileImageUrl] = useState(
+    userInfo?.profileImageUrl || '/public/file.svg',
+  );
+
+  // const handleProfileImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   const file = e.target.files?.[0];
+  //   if (file) {
+  //     const imageUrl = URL.createObjectURL(file); // 임시 URL로 설정
+  //     setProfileImageUrl(imageUrl);
+  //     setUserInfo({ ...userInfo, profileImageUrl: imageUrl }); // 상태 업데이트
+  //   }
+  // };
+
+  // const handleImageDelete = () => {
+  //   setProfileImageUrl('');
+  //   setUserInfo({ ...userInfo, profileImageUrl: '' }); // 상태에서 프로필 이미지 제거
+  // };
+
+  return (
+    <div className="flex flex-col md:flex-row gap-8 p-8 max-w-4xl mx-auto">
+      <div className="flex flex-col items-center w-full md:w-1/3 border-r pr-4">
+        <div className="relative">
+          <img
+            src={profileImageUrl || '/default-avatar.png'}
+            alt="Profile"
+            className="w-32 h-32 rounded-full object-cover border"
+          />
+        </div>
+        <div className="mt-4 flex flex-col gap-4 w-full">
+          {profileImageUrl && (
+            <button
+              // onClick={handleImageDelete}
+              className="btn btn-error w-full"
+            >
+              이미지 삭제
+            </button>
+          )}
+          <label className="btn btn-primary w-full cursor-pointer">
+            이미지 변경
+            <input
+              type="file"
+              className="hidden"
+              // onChange={handleProfileImageChange}
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="flex flex-col w-full md:w-2/3 space-y-6">
+        <form className="space-y-4">
+          <div className="flex items-center gap-4">
+            <label className="font-medium text-lg">닉네임:</label>
+            <input
+              type="text"
+              value={nickname}
+              onChange={e => setNickname(e.target.value)}
+              className="input input-bordered w-full"
+            />
+            <button type="submit" className="btn btn-primary">
+              닉네임 수정
+            </button>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <label className="font-medium text-lg">이메일:</label>
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="input input-bordered w-full"
+            />
+            <button type="button" className="btn btn-secondary">
+              비밀번호 수정
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default UserInfoView;

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -11,7 +11,8 @@ type HeaderProps = {
   initialSignedIn: boolean;
 };
 const Header = ({ initialSignedIn }: HeaderProps) => {
-  const { isSignedIn, setIsSignedIn, setUserInfo, userInfo } = useAuthStore();
+  const { isSignedIn, setIsSignedIn, setUserInfo, userInfo, resetStore } =
+    useAuthStore();
 
   const pathname = usePathname();
   const router = useRouter();
@@ -51,7 +52,7 @@ const Header = ({ initialSignedIn }: HeaderProps) => {
       );
       if (response.status === 200) {
         // 로그아웃 후 상태 변경
-        setIsSignedIn(false);
+        resetStore();
         router.push('/');
       }
     } catch (error: any) {
@@ -117,7 +118,7 @@ const Header = ({ initialSignedIn }: HeaderProps) => {
       <div className="navbar-end">
         {isSignedIn ? (
           <>
-            <Link href="/mypage/1" className="btn btn-ghost text-base-content">
+            <Link href={`/mypage/${userInfo?.id}`} className="btn btn-ghost">
               마이페이지
             </Link>
             <button

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  console.log('미들웨어 실행됨:', request.nextUrl.pathname);
+  const accessToken = request.cookies.get('accessToken')?.value;
+
+  // 로그 출력으로 미들웨어가 정상적으로 동작하는지 확인
+  console.log('미들웨어 실행 - 요청 경로:', request.nextUrl.pathname);
+
+  // 인증이 필요한 경로를 보호
+  if (accessToken) {
+    console.log('AccessToken 존재:', accessToken);
+    return NextResponse.next({
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+  }
+  // 기본적으로 요청을 계속 진행
+  console.log('AccessToken 없음');
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/api/:path*'], // 특정 경로에서만 동작
+};

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 type UserInfo = {
   id: number;
@@ -12,11 +13,21 @@ type AuthState = {
   setIsSignedIn: (status: boolean) => void;
   userInfo: UserInfo | null;
   setUserInfo: (info: UserInfo | null) => void;
+  resetStore: () => void;
 };
 
-export const useAuthStore = create<AuthState>(set => ({
-  isSignedIn: false,
-  userInfo: null,
-  setIsSignedIn: status => set(() => ({ isSignedIn: status })),
-  setUserInfo: info => set(() => ({ userInfo: info })),
-}));
+export const useAuthStore = create<AuthState>()(
+  persist(
+    set => ({
+      isSignedIn: false,
+      userInfo: null,
+      setIsSignedIn: status => set(() => ({ isSignedIn: status })),
+      setUserInfo: info => set(() => ({ userInfo: info })),
+      resetStore: () => set(() => ({ isSignedIn: false, userInfo: null })),
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 인증 헤더에 토큰이 필요한 경우
  - 서버 컴포넌트에서 토큰을 가져오거나, Next.js API Route 안에서 토큰을 인증 헤더에 추가하도록 구현
- 마이페이지
  - 회원정보 UI 구현되지 않음
- 전역상태 관리
  - 상태가 유지되지 않음 (새로고침 시 상태값 사라짐)
  - 상태 초기화 메서드 없음
- 로그아웃
  - 로그아웃 해도 상태 초기화 되지 않음
  - 인증 헤더 설정 부분 Next.js API Route에서 처리

**TO-BE**
- 마이페이지
  - 동적 경로 수정하여 마이페이지로 이동 시, userId에 맞는 페이지가 보이도록 구현
  - 회원 정보 UI 구현
- 전역 상태 관리
  - zustand `persist` 사용하여 새로 고침 시에도 상태값 유지
  - 상태 초기화 메서드 구현
- 로그아웃
  - 상태 초기화 메서드 호출하여, 로그아웃 시 모든 상태값(유저정보) 초기화
  - 인증 헤더 토큰 설정하는 부분을 미들웨어에서 토큰 처리하는 것으로 대체
 - 미들웨어
   - 미들웨어에서 인증 헤더에 토큰을 설정하여 요청 시 미들웨어가 토큰을 자동으로 처리하도록 구현
- 마이페이지
  - 상태에 따라 마이페이지를 다르게 렌더링
  - 미들웨어 추가하여 인증 헤더에 토큰 설정 구현
 
### 테스트
- [X] 로그아웃 시 미들웨어 실행 테스트
- [X] 로그아웃 시 상태 초기화 테스트

### ️📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/11bbe070-c433-4acd-8b86-18bd49893a13)