### PR TITLE
feat: 스터디 신청/마감 관련 API 연동 수정

### DIFF
--- a/src/app/api/comments/[commentId]/reply/route.ts
+++ b/src/app/api/comments/[commentId]/reply/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import axios from 'axios';
 
-export async function POST(req: NextRequest) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { commentId: string } },
+) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
 
@@ -16,13 +19,12 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const response = await axios.post(
-      `${process.env.API_URL}/comments`,
+      `${process.env.API_URL}/comments/${params.commentId}/reply`,
       {
         post_id: body.post_id,
         post_type: body.post_type,
         is_secret: body.is_secret,
         content: body.content,
-        ...(body.reply_to && { reply_to: body.reply_to }),
       },
       {
         headers: {
@@ -34,7 +36,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(response.data);
   } catch {
     return NextResponse.json(
-      { message: '댓글 작성에 실패했습니다.' },
+      { message: '대댓글 작성에 실패했습니다.' },
       { status: 500 },
     );
   }

--- a/src/app/api/info-posts/[id]/route.ts
+++ b/src/app/api/info-posts/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import axios from 'axios';
+import { cookies } from 'next/headers';
 
 export async function GET(
   req: NextRequest,
@@ -8,9 +8,30 @@ export async function GET(
 ) {
   try {
     const response = await axios.get(
-      `${process.env.API_BASE_URL}/info-posts/${params.id}`,
+      `${process.env.API_URL}/info-posts/${params.id}`,
     );
-    return NextResponse.json(response.data);
+
+    const post = response.data;
+
+    // 응답 형식을 명세서에 맞게 변환
+    const formattedResponse = {
+      id: post.id,
+      user: {
+        id: post.user.id,
+        username: post.user.username,
+        email: post.user.email,
+        profileImageUrl: post.user.profileImageUrl,
+        isActive: post.user.isActive,
+        createdAt: post.user.createdAt,
+        updatedAt: post.user.updatedAt,
+      },
+      title: post.title,
+      content: post.content,
+      createdAt: post.createdAt,
+      updatedAt: post.updatedAt,
+    };
+
+    return NextResponse.json(formattedResponse);
   } catch (error) {
     console.error('게시글 조회 실패:', error);
     return NextResponse.json(
@@ -24,32 +45,58 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-
-  if (!accessToken) {
-    return NextResponse.json(
-      { message: '인증이 필요합니다.' },
-      { status: 401 },
-    );
-  }
-
   try {
-    const body = await req.json();
-    const response = await axios.put(
-      `${process.env.API_BASE_URL}/info-posts/${params.id}`,
-      body,
+    const formData = await req.formData();
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get('accessToken')?.value;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: '인증이 필요합니다.' },
+        { status: 401 },
+      );
+    }
+
+    const file = formData.get('thumbnail');
+    const transformedFormData = new FormData();
+
+    if (file && file instanceof File) {
+      transformedFormData.append('thumbnail', file);
+    }
+
+    const fields = {
+      title: formData.get('title'),
+      content: formData.get('content'),
+      userId: formData.get('userId'),
+    };
+
+    Object.entries(fields).forEach(([key, value]) => {
+      if (value !== undefined) {
+        transformedFormData.append(key, String(value));
+      }
+    });
+
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/info-posts/${params.id}`,
       {
+        method: 'PUT',
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
+        body: transformedFormData,
       },
     );
-    return NextResponse.json(response.data);
+
+    if (!response.ok) {
+      throw new Error('정보공유 글 수정 실패');
+    }
+
+    const responseData = await response.json();
+    return NextResponse.json(responseData, { status: response.status });
   } catch (error) {
-    console.error('게시글 수정 실패:', error);
+    console.error('API Route 에러:', error);
     return NextResponse.json(
-      { message: '게시글 수정에 실패했습니다.' },
+      { message: '정보공유 글 수정에 실패했습니다.' },
       { status: 500 },
     );
   }

--- a/src/app/api/qna-posts/[id]/route.ts
+++ b/src/app/api/qna-posts/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import axios from 'axios';
+import { cookies } from 'next/headers';
 
 export async function GET(
   req: NextRequest,
@@ -8,9 +8,30 @@ export async function GET(
 ) {
   try {
     const response = await axios.get(
-      `${process.env.API_BASE_URL}/qna-posts/${params.id}`,
+      `${process.env.API_URL}/qna-posts/${params.id}`,
     );
-    return NextResponse.json(response.data);
+
+    const post = response.data;
+
+    // 응답 형식을 명세서에 맞게 변환
+    const formattedResponse = {
+      id: post.id,
+      user: {
+        id: post.user.id,
+        username: post.user.username,
+        email: post.user.email,
+        profileImageUrl: post.user.profileImageUrl,
+        isActive: post.user.isActive,
+        createdAt: post.user.createdAt,
+        updatedAt: post.user.updatedAt,
+      },
+      title: post.title,
+      content: post.content,
+      createdAt: post.createdAt,
+      updatedAt: post.updatedAt,
+    };
+
+    return NextResponse.json(formattedResponse);
   } catch (error) {
     console.error('게시글 조회 실패:', error);
     return NextResponse.json(
@@ -24,32 +45,58 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-
-  if (!accessToken) {
-    return NextResponse.json(
-      { message: '인증이 필요합니다.' },
-      { status: 401 },
-    );
-  }
-
   try {
-    const body = await req.json();
-    const response = await axios.put(
-      `${process.env.API_BASE_URL}/qna-posts/${params.id}`,
-      body,
+    const formData = await req.formData();
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get('accessToken')?.value;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: '인증이 필요합니다.' },
+        { status: 401 },
+      );
+    }
+
+    const file = formData.get('thumbnail');
+    const transformedFormData = new FormData();
+
+    if (file && file instanceof File) {
+      transformedFormData.append('thumbnail', file);
+    }
+
+    const fields = {
+      title: formData.get('title'),
+      content: formData.get('content'),
+      userId: formData.get('userId'),
+    };
+
+    Object.entries(fields).forEach(([key, value]) => {
+      if (value !== undefined) {
+        transformedFormData.append(key, String(value));
+      }
+    });
+
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/qna-posts/${params.id}`,
       {
+        method: 'PUT',
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
+        body: transformedFormData,
       },
     );
-    return NextResponse.json(response.data);
+
+    if (!response.ok) {
+      throw new Error('Q&A 글 수정 실패');
+    }
+
+    const responseData = await response.json();
+    return NextResponse.json(responseData, { status: response.status });
   } catch (error) {
-    console.error('게시글 수정 실패:', error);
+    console.error('API Route 에러:', error);
     return NextResponse.json(
-      { message: '게시글 수정에 실패했습니다.' },
+      { message: 'Q&A 글 수정에 실패했습니다.' },
       { status: 500 },
     );
   }

--- a/src/app/api/qna-posts/route.ts
+++ b/src/app/api/qna-posts/route.ts
@@ -1,5 +1,6 @@
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import axios from 'axios';
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,49 +15,44 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // 파일 처리
-    const thumbnail = formData.get('thumbnail');
+    const file = formData.get('file');
     const transformedFormData = new FormData();
 
-    if (thumbnail && thumbnail instanceof File) {
-      transformedFormData.append('thumbnail', thumbnail);
+    if (file && file instanceof File) {
+      transformedFormData.append('file', file);
     }
 
-    // 나머지 필드들 추가
     const fields = {
       title: formData.get('title'),
       content: formData.get('content'),
-      userId: Number(formData.get('userId')),
     };
 
-    // FormData에 필드 추가
     Object.entries(fields).forEach(([key, value]) => {
       if (value !== undefined) {
         transformedFormData.append(key, String(value));
       }
     });
 
-    const response = await fetch(
+    const response = await axios.post(
       `${process.env.NEXT_PUBLIC_API_URL}/qna-posts`,
+      transformedFormData,
       {
-        method: 'POST',
         headers: {
+          'Content-Type': 'multipart/form-data',
           Authorization: `Bearer ${accessToken}`,
         },
-        body: transformedFormData,
       },
     );
 
-    if (!response.ok) {
-      throw new Error('QnA 글 작성 실패');
+    if (response.status !== 200) {
+      throw new Error('Q&A 글 작성 실패');
     }
 
-    const responseData = await response.json();
-    return NextResponse.json(responseData, { status: response.status });
+    return NextResponse.json(response.data, { status: response.status });
   } catch (error) {
     console.error('API Route 에러:', error);
     return NextResponse.json(
-      { message: 'QnA 글 작성에 실패했습니다.' },
+      { message: 'Q&A 글 작성에 실패했습니다.' },
       { status: 500 },
     );
   }

--- a/src/app/api/study-posts/[id]/cancel/route.ts
+++ b/src/app/api/study-posts/[id]/cancel/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import axios from 'axios';
 
-export async function POST(req: NextRequest) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
 
@@ -14,16 +17,9 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const body = await req.json();
-    const response = await axios.post(
-      `${process.env.API_URL}/comments`,
-      {
-        post_id: body.post_id,
-        post_type: body.post_type,
-        is_secret: body.is_secret,
-        content: body.content,
-        ...(body.reply_to && { reply_to: body.reply_to }),
-      },
+    const response = await axios.patch(
+      `${process.env.API_URL}/study-posts/${params.id}/cancel`,
+      {},
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -32,9 +28,10 @@ export async function POST(req: NextRequest) {
     );
 
     return NextResponse.json(response.data);
-  } catch {
+  } catch (error) {
+    console.error('스터디 모집 취소 실패:', error);
     return NextResponse.json(
-      { message: '댓글 작성에 실패했습니다.' },
+      { message: '스터디 모집 취소에 실패했습니다.' },
       { status: 500 },
     );
   }

--- a/src/app/api/study-posts/[id]/close/route.ts
+++ b/src/app/api/study-posts/[id]/close/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import axios from 'axios';
 
-export async function POST(req: NextRequest) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
 
@@ -14,16 +17,9 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const body = await req.json();
-    const response = await axios.post(
-      `${process.env.API_URL}/comments`,
-      {
-        post_id: body.post_id,
-        post_type: body.post_type,
-        is_secret: body.is_secret,
-        content: body.content,
-        ...(body.reply_to && { reply_to: body.reply_to }),
-      },
+    const response = await axios.patch(
+      `${process.env.API_URL}/study-posts/${params.id}/close`,
+      {},
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -32,9 +28,10 @@ export async function POST(req: NextRequest) {
     );
 
     return NextResponse.json(response.data);
-  } catch {
+  } catch (error) {
+    console.error('스터디 모집 마감 실패:', error);
     return NextResponse.json(
-      { message: '댓글 작성에 실패했습니다.' },
+      { message: '스터디 모집 마감에 실패했습니다.' },
       { status: 500 },
     );
   }

--- a/src/app/api/study-posts/[id]/route.ts
+++ b/src/app/api/study-posts/[id]/route.ts
@@ -1,40 +1,5 @@
 import axios from 'axios';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
-
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: { id: string } },
-) {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-
-  if (!accessToken) {
-    return NextResponse.json(
-      { message: '인증이 필요합니다.' },
-      { status: 401 },
-    );
-  }
-
-  try {
-    await axios.put(
-      `${process.env.API_BASE_URL}/study-posts/${params.id}/close`,
-      { status: 'CANCELED' },
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
-
-    return NextResponse.json({ message: '스터디 모집이 취소되었습니다.' });
-  } catch {
-    return NextResponse.json(
-      { message: '스터디 모집 취소에 실패했습니다.' },
-      { status: 500 },
-    );
-  }
-}
 
 export async function GET(
   req: NextRequest,

--- a/src/app/api/study-signup/[signupId]/route.ts
+++ b/src/app/api/study-signup/[signupId]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import axios from 'axios';
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { signupId: string } },
+) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: '인증이 필요합니다.' },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const status = req.nextUrl.searchParams.get('newStatus');
+
+    if (!status || !['APPROVED', 'REJECTED'].includes(status)) {
+      return NextResponse.json(
+        { message: '잘못된 상태값입니다.' },
+        { status: 400 },
+      );
+    }
+
+    const response = await axios.patch(
+      `${process.env.API_URL}/study-signup/${params.signupId}?newStatus=${status}`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    return NextResponse.json(response.data);
+  } catch (error) {
+    console.error('신청 상태 변경 실패:', error);
+    return NextResponse.json(
+      { message: '신청 상태 변경에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { signupId: string } },
+) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: '인증이 필요합니다.' },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const response = await axios.delete(
+      `${process.env.API_URL}/study-signup/${params.signupId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    return NextResponse.json(response.data);
+  } catch (error) {
+    console.error('스터디 신청 취소 실패:', error);
+    return NextResponse.json(
+      { message: '스터디 신청 취소에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/study-signup/route.ts
+++ b/src/app/api/study-signup/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import axios from 'axios';
+
+export async function GET(req: NextRequest) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: '인증이 필요합니다.' },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const studyPostId = req.nextUrl.searchParams.get('studyPostId');
+    const status = req.nextUrl.searchParams.get('status');
+
+    if (!studyPostId) {
+      return NextResponse.json(
+        { message: '스터디 ID가 필요합니다.' },
+        { status: 400 },
+      );
+    }
+
+    const response = await axios.get(
+      `${process.env.API_URL}/study-signup?studyPostId=${studyPostId}${
+        status ? `&status=${status}` : ''
+      }`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    return NextResponse.json(response.data);
+  } catch (error) {
+    console.error('스터디 신청 목록 조회 실패:', error);
+    return NextResponse.json(
+      { message: '스터디 신청 목록 조회에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: '인증이 필요합니다.' },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const body = await req.json();
+    console.log('Request body:', body);
+
+    const response = await axios.post(
+      `${process.env.API_URL}/study-signup`,
+      {
+        studyPostId: Number(body.studyPostId),
+        userId: Number(body.userId),
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const applicationData = response.data;
+    const formattedResponse = {
+      signupId: applicationData.signupId,
+      user: {
+        id: applicationData.user.id,
+        nickname: applicationData.user.nickname,
+        email: applicationData.user.email,
+        profileImageUrl: applicationData.user.profileImageUrl,
+        isActive: applicationData.user.isActive,
+        createdAt: applicationData.user.createdAt,
+        updatedAt: applicationData.user.updatedAt,
+      },
+      nickName: applicationData.user.nickname,
+      status: applicationData.status,
+    };
+
+    return NextResponse.json(formattedResponse);
+  } catch (error) {
+    console.error('스터디 신청 실패:', error);
+    return NextResponse.json(
+      { message: '스터디 신청에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/study/[id]/participants/route.ts
+++ b/src/app/api/study/[id]/participants/route.ts
@@ -18,7 +18,7 @@ export async function GET(
 
   try {
     const response = await axios.get(
-      `${process.env.API_BASE_URL}/api/study/${params.id}/participants`,
+      `${process.env.API_URL}/study/${params.id}/participants`,
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -27,7 +27,8 @@ export async function GET(
     );
 
     return NextResponse.json(response.data);
-  } catch {
+  } catch (error) {
+    console.error('참여자 목록 조회 실패:', error);
     return NextResponse.json(
       { message: '참여자 목록 조회에 실패했습니다.' },
       { status: 500 },

--- a/src/app/community/components/PostList.tsx
+++ b/src/app/community/components/PostList.tsx
@@ -14,6 +14,8 @@ interface PostListProps<T extends BasePost> {
   renderPostCard: (post: T) => React.ReactNode;
   showFilters?: boolean;
   filterComponent?: React.ReactNode;
+  onWrite?: () => void;
+  isSignedIn?: boolean;
 }
 
 export function PostList<T extends BasePost>({
@@ -27,6 +29,8 @@ export function PostList<T extends BasePost>({
   renderPostCard,
   showFilters = false,
   filterComponent,
+  onWrite,
+  isSignedIn,
 }: PostListProps<T>) {
   const handleSearchInput = useCallback(
     debounce((value: string) => {
@@ -39,7 +43,14 @@ export function PostList<T extends BasePost>({
 
   return (
     <div className="w-full">
-      {title && <h1 className="text-2xl font-bold mb-6">{title}</h1>}
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {onWrite && isSignedIn && (
+          <button onClick={onWrite} className="btn btn-primary">
+            글쓰기
+          </button>
+        )}
+      </div>
 
       <div className="mb-6">
         <form

--- a/src/app/community/info/page.tsx
+++ b/src/app/community/info/page.tsx
@@ -9,11 +9,11 @@ import { useAuthStore } from '@/store/authStore';
 
 export default function InfoListPage() {
   const router = useRouter();
-  const { isSignedIn } = useAuthStore();
   const [posts, setPosts] = useState<PostResponse<InfoPost> | null>(null);
   const [page, setPage] = useState(0);
   const [searchTitle, setSearchTitle] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const { isSignedIn } = useAuthStore();
 
   const fetchPosts = async () => {
     setIsLoading(true);
@@ -24,7 +24,9 @@ export default function InfoListPage() {
         searchTitle,
       });
 
-      const response = await axios.get('/api/info-posts/search', { params });
+      const response = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/info-posts?${params}`,
+      );
       setPosts(response.data);
     } catch (error) {
       console.error('정보공유 목록 조회 실패:', error);
@@ -37,51 +39,46 @@ export default function InfoListPage() {
     fetchPosts();
   }, [page, searchTitle]);
 
+  const handleWrite = () => {
+    router.push('/community/info/write');
+  };
+
   return (
-    <div>
-      <PostList<InfoPost>
-        title="정보공유"
-        posts={posts?.data || []}
-        totalPages={posts?.total_pages || 0}
-        currentPage={page}
-        isLoading={isLoading}
-        onPageChange={setPage}
-        onSearch={setSearchTitle}
-        renderPostCard={post => (
-          <div key={post.id} className="card bg-base-100 shadow-xl">
-            <figure className="px-4 pt-4">
-              <img
-                src={post.thumbnail || '/default-info-thumbnail.png'}
-                alt={post.title}
-                className="rounded-xl h-48 w-full object-cover"
-              />
-            </figure>
-            <div className="card-body">
-              <h2 className="card-title">{post.title}</h2>
-              <p className="text-base-content/70">
-                {post.content.slice(0, 100)}...
-              </p>
-              <div className="card-actions justify-end mt-4">
-                <button
-                  className="btn btn-primary btn-sm"
-                  onClick={() => router.push(`/community/info/${post.id}`)}
-                >
-                  상세보기
-                </button>
-              </div>
+    <PostList<InfoPost>
+      title="정보공유"
+      posts={posts?.data || []}
+      totalPages={posts?.total_pages || 0}
+      currentPage={page}
+      isLoading={isLoading}
+      onPageChange={setPage}
+      onSearch={setSearchTitle}
+      onWrite={handleWrite}
+      isSignedIn={isSignedIn}
+      renderPostCard={post => (
+        <div key={post.id} className="card bg-base-100 shadow-xl">
+          <figure className="px-4 pt-4">
+            <img
+              src={post.thumbnail || '/default-info-thumbnail.png'}
+              alt={post.title}
+              className="rounded-xl h-48 w-full object-cover"
+            />
+          </figure>
+          <div className="card-body">
+            <h2 className="card-title">{post.title}</h2>
+            <p className="text-base-content/70">
+              {post.content.slice(0, 100)}...
+            </p>
+            <div className="card-actions justify-end mt-4">
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => router.push(`/community/info/${post.id}`)}
+              >
+                상세보기
+              </button>
             </div>
           </div>
-        )}
-      />
-
-      {isSignedIn && (
-        <button
-          onClick={() => router.push('/community/info/write')}
-          className="btn btn-primary"
-        >
-          글쓰기
-        </button>
+        </div>
       )}
-    </div>
+    />
   );
 }

--- a/src/app/community/info/write/page.tsx
+++ b/src/app/community/info/write/page.tsx
@@ -8,8 +8,8 @@ import axios from 'axios';
 export default function InfoWritePage() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [thumbnailPreview, setThumbnailPreview] = useState<string | null>(null);
-  const { isSignedIn, userInfo } = useAuthStore();
+  const [filePreview, setFilePreview] = useState<string | null>(null);
+  const { isSignedIn } = useAuthStore();
   const router = useRouter();
 
   useEffect(() => {
@@ -18,12 +18,12 @@ export default function InfoWritePage() {
     }
   }, [isSignedIn]);
 
-  const handleThumbnailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const reader = new FileReader();
       reader.onloadend = () => {
-        setThumbnailPreview(reader.result as string);
+        setFilePreview(reader.result as string);
       };
       reader.readAsDataURL(file);
     }
@@ -34,17 +34,16 @@ export default function InfoWritePage() {
     try {
       const formData = new FormData();
       const fileInput = (e.target as HTMLFormElement).querySelector(
-        'input[name="thumbnail"]',
+        'input[name="file"]',
       ) as HTMLInputElement;
       const file = fileInput.files?.[0];
 
       if (file) {
-        formData.append('thumbnail', file);
+        formData.append('file', file);
       }
 
       formData.append('title', title);
       formData.append('content', content);
-      formData.append('userId', String(userInfo?.id));
 
       await axios.post('/api/info-posts', formData, {
         headers: {
@@ -62,20 +61,20 @@ export default function InfoWritePage() {
     <form onSubmit={handleSubmit} className="max-w-4xl mx-auto p-4 space-y-4">
       <div className="form-control">
         <label className="label">
-          <span className="label-text">썸네일 이미지</span>
+          <span className="label-text">이미지</span>
         </label>
         <input
           type="file"
-          name="thumbnail"
+          name="file"
           accept="image/*"
-          onChange={handleThumbnailChange}
+          onChange={handleFileChange}
           className="file-input file-input-bordered w-full"
         />
-        {thumbnailPreview && (
+        {filePreview && (
           <div className="mt-2">
             <img
-              src={thumbnailPreview}
-              alt="썸네일 미리보기"
+              src={filePreview}
+              alt="이미지 미리보기"
               className="w-full max-w-xs rounded-lg"
             />
           </div>

--- a/src/app/community/qna/[id]/page.tsx
+++ b/src/app/community/qna/[id]/page.tsx
@@ -1,11 +1,29 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { QnAPost } from '@/types/post';
 import { useAuthStore } from '@/store/authStore';
 import { useRouter } from 'next/navigation';
-import dayjs from 'dayjs';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
+import dayjs from 'dayjs';
+
+interface User {
+  id: number;
+  username: string;
+  email: string;
+  profileImageUrl: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface QnAPost {
+  id: number;
+  user: User;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
 
 export default function QnADetailPage({ params }: { params: { id: string } }) {
   const [post, setPost] = useState<QnAPost | null>(null);
@@ -25,22 +43,7 @@ export default function QnADetailPage({ params }: { params: { id: string } }) {
     fetchPost();
   }, [params.id]);
 
-  const isAuthor = isSignedIn && userInfo?.id === post?.userId;
-
-  const handleEdit = () => {
-    router.push(`/community/qna/edit/${params.id}`);
-  };
-
-  const handleDelete = async () => {
-    if (!window.confirm('정말로 이 게시글을 삭제하시겠습니까?')) return;
-
-    try {
-      await axios.delete(`/api/qna-posts/${params.id}`);
-      router.push('/community/qna');
-    } catch (error) {
-      console.error('게시글 삭제 실패:', error);
-    }
-  };
+  const isAuthor = isSignedIn && userInfo?.id === post?.user.id;
 
   if (!post) return <div>Loading...</div>;
 
@@ -49,8 +52,11 @@ export default function QnADetailPage({ params }: { params: { id: string } }) {
       <div className="bg-base-100 shadow-xl rounded-lg p-6">
         <div className="mb-6">
           <h1 className="text-2xl font-bold mb-4">{post.title}</h1>
-          <div className="text-sm text-base-content/60">
-            작성일: {dayjs(post.createdAt).format('YYYY.MM.DD HH:mm')}
+          <div className="flex justify-between text-sm text-base-content/60">
+            <span>작성자: {post.user.username}</span>
+            <span>
+              작성일: {dayjs(post.createdAt).format('YYYY.MM.DD HH:mm')}
+            </span>
           </div>
         </div>
         <div className="prose max-w-none">
@@ -59,10 +65,25 @@ export default function QnADetailPage({ params }: { params: { id: string } }) {
 
         {isAuthor && (
           <div className="flex gap-2 mt-4">
-            <button onClick={handleEdit} className="btn btn-primary">
+            <button
+              onClick={() => router.push(`/community/qna/edit/${post.id}`)}
+              className="btn btn-primary"
+            >
               수정
             </button>
-            <button onClick={handleDelete} className="btn btn-error">
+            <button
+              onClick={async () => {
+                if (window.confirm('정말로 삭제하시겠습니까?')) {
+                  try {
+                    await axios.delete(`/api/qna-posts/${post.id}`);
+                    router.push('/community/qna');
+                  } catch (error) {
+                    console.error('삭제 실패:', error);
+                  }
+                }
+              }}
+              className="btn btn-error"
+            >
               삭제
             </button>
           </div>

--- a/src/app/community/qna/page.tsx
+++ b/src/app/community/qna/page.tsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { QnAPost, PostResponse } from '@/types/post';
 import { PostList } from '../components/PostList';
 import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
 
 export default function QnAListPage() {
   const router = useRouter();
@@ -22,7 +23,9 @@ export default function QnAListPage() {
         searchTitle,
       });
 
-      const response = await axios.get('/api/qna-posts/search', { params });
+      const response = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/qna-posts?${params}`,
+      );
       setPosts(response.data);
     } catch (error) {
       console.error('Q&A 목록 조회 실패:', error);
@@ -35,6 +38,12 @@ export default function QnAListPage() {
     fetchPosts();
   }, [page, searchTitle]);
 
+  const { isSignedIn } = useAuthStore();
+
+  const handleWrite = () => {
+    router.push('/community/qna/write');
+  };
+
   return (
     <PostList<QnAPost>
       title="Q&A"
@@ -44,6 +53,8 @@ export default function QnAListPage() {
       isLoading={isLoading}
       onPageChange={setPage}
       onSearch={setSearchTitle}
+      onWrite={handleWrite}
+      isSignedIn={isSignedIn}
       renderPostCard={post => (
         <div key={post.id} className="card bg-base-100 shadow-xl">
           <figure className="px-4 pt-4">

--- a/src/app/community/qna/write/page.tsx
+++ b/src/app/community/qna/write/page.tsx
@@ -8,8 +8,8 @@ import axios from 'axios';
 export default function QnAWritePage() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [thumbnailPreview, setThumbnailPreview] = useState<string | null>(null);
-  const { isSignedIn, userInfo } = useAuthStore();
+  const [filePreview, setFilePreview] = useState<string | null>(null);
+  const { isSignedIn } = useAuthStore();
   const router = useRouter();
 
   useEffect(() => {
@@ -18,12 +18,12 @@ export default function QnAWritePage() {
     }
   }, [isSignedIn]);
 
-  const handleThumbnailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const reader = new FileReader();
       reader.onloadend = () => {
-        setThumbnailPreview(reader.result as string);
+        setFilePreview(reader.result as string);
       };
       reader.readAsDataURL(file);
     }
@@ -34,17 +34,16 @@ export default function QnAWritePage() {
     try {
       const formData = new FormData();
       const fileInput = (e.target as HTMLFormElement).querySelector(
-        'input[name="thumbnail"]',
+        'input[name="file"]',
       ) as HTMLInputElement;
       const file = fileInput.files?.[0];
 
       if (file) {
-        formData.append('thumbnail', file);
+        formData.append('file', file);
       }
 
       formData.append('title', title);
       formData.append('content', content);
-      formData.append('userId', String(userInfo?.id));
 
       await axios.post('/api/qna-posts', formData, {
         headers: {
@@ -62,20 +61,20 @@ export default function QnAWritePage() {
     <form onSubmit={handleSubmit} className="max-w-4xl mx-auto p-4 space-y-4">
       <div className="form-control">
         <label className="label">
-          <span className="label-text">썸네일 이미지</span>
+          <span className="label-text">이미지</span>
         </label>
         <input
           type="file"
-          name="thumbnail"
+          name="file"
           accept="image/*"
-          onChange={handleThumbnailChange}
+          onChange={handleFileChange}
           className="file-input file-input-bordered w-full"
         />
-        {thumbnailPreview && (
+        {filePreview && (
           <div className="mt-2">
             <img
-              src={thumbnailPreview}
-              alt="썸네일 미리보기"
+              src={filePreview}
+              alt="이미지 미리보기"
               className="w-full max-w-xs rounded-lg"
             />
           </div>

--- a/src/app/community/study/[id]/components/StudyDetailContent.tsx
+++ b/src/app/community/study/[id]/components/StudyDetailContent.tsx
@@ -56,7 +56,7 @@ export default function StudyDetailContent({
     if (!window.confirm('정말로 이 스터디 모집을 취소하시겠습니까?')) return;
 
     try {
-      const response = await axios.put(`/api/study-posts/${studyId}/close`);
+      const response = await axios.patch(`/api/study-posts/${studyId}/cancel`);
       if (response.status === 200) {
         setStudy(prev => {
           if (!prev) return prev;

--- a/src/app/community/study/components/HybridStudyList.tsx
+++ b/src/app/community/study/components/HybridStudyList.tsx
@@ -9,7 +9,7 @@ import { StudyFilter } from './StudyFilter';
 import { StudyCard } from './StudyCard';
 import KakaoMap from './KakaoMap';
 
-type FilterType = 'subjects' | 'status' | 'difficulty' | 'days';
+type FilterType = 'subjects' | 'status' | 'difficulty' | 'dayType';
 
 export default function HybridStudyList() {
   const router = useRouter();
@@ -24,7 +24,7 @@ export default function HybridStudyList() {
   const selectedSubjects = searchParams.getAll('subjects');
   const selectedStatus = searchParams.getAll('status');
   const selectedDifficulty = searchParams.getAll('difficulty');
-  const selectedDays = searchParams.getAll('days');
+  const selectedDays = searchParams.getAll('dayType');
 
   useEffect(() => {
     if (navigator.geolocation) {
@@ -76,7 +76,7 @@ export default function HybridStudyList() {
       selectedDifficulty.forEach(difficulty =>
         params.append('difficulty[]', difficulty),
       );
-      selectedDays.forEach(day => params.append('days[]', day));
+      selectedDays.forEach(day => params.append('dayType[]', day));
 
       const response = await axios.get(
         `${process.env.NEXT_PUBLIC_API_URL}/study-posts/search`,

--- a/src/app/community/study/components/OnlineStudyList.tsx
+++ b/src/app/community/study/components/OnlineStudyList.tsx
@@ -7,7 +7,7 @@ import { StudyResponse, StudyPost } from '@/types/study';
 import { StudyFilter } from './StudyFilter';
 import { StudyCard } from './StudyCard';
 
-type FilterType = 'subjects' | 'status' | 'difficulty' | 'days';
+type FilterType = 'subjects' | 'status' | 'difficulty' | 'dayType';
 
 export default function OnlineStudyList() {
   const router = useRouter();
@@ -18,7 +18,7 @@ export default function OnlineStudyList() {
   const selectedSubjects = searchParams.getAll('subjects');
   const selectedStatus = searchParams.getAll('status');
   const selectedDifficulty = searchParams.getAll('difficulty');
-  const selectedDays = searchParams.getAll('days');
+  const selectedDays = searchParams.getAll('dayType');
 
   const { data: posts, isLoading } = useQuery<StudyResponse>({
     queryKey: [

--- a/src/app/community/study/components/StudyFilter.tsx
+++ b/src/app/community/study/components/StudyFilter.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-type FilterType = 'subjects' | 'status' | 'difficulty' | 'days';
+type FilterType = 'subjects' | 'status' | 'difficulty' | 'dayType';
 
 // 영어 Enum -> 한글 표시용 매핑
 const STATUS_DISPLAY = {
   RECRUITING: '모집 중',
-  IN_PROGRESS: '진행 중',
-  CANCELED: '종료',
+  CLOSED: '모집 완료',
+  CANCELED: '모집 취소',
 };
 
 const DIFFICULTY_DISPLAY = {
@@ -101,7 +101,7 @@ export function StudyFilter({
             {['월', '화', '수', '목', '금', '토', '일'].map(day => (
               <button
                 key={day}
-                onClick={() => onFilterChange('days', day)}
+                onClick={() => onFilterChange('dayType', day)}
                 className={`btn btn-sm ${
                   selectedDays.includes(day) ? 'btn-primary' : 'btn-outline'
                 }`}

--- a/src/app/community/study/page.tsx
+++ b/src/app/community/study/page.tsx
@@ -22,7 +22,7 @@ export default function StudyListPage() {
       subjects: newSearchParams.getAll('subjects'),
       status: newSearchParams.getAll('status'),
       difficulty: newSearchParams.getAll('difficulty'),
-      days: newSearchParams.getAll('days'),
+      dayType: newSearchParams.getAll('dayType'),
     };
 
     newSearchParams.set('type', type);
@@ -36,7 +36,9 @@ export default function StudyListPage() {
     currentFilters.difficulty.forEach(difficulty =>
       newSearchParams.append('difficulty', difficulty),
     );
-    currentFilters.days.forEach(day => newSearchParams.append('days', day));
+    currentFilters.dayType.forEach(day =>
+      newSearchParams.append('dayType', day),
+    );
 
     router.push(`?${newSearchParams.toString()}`);
   };

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,11 +1,7 @@
 export interface Application {
-  id: number;
+  signupId: number;
   userId: number;
-  studyId: number;
-  status: 'PENDING' | 'ACCEPTED' | 'REJECTED';
+  nickname: string;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED';
   createdAt: string;
-  user: {
-    id: number;
-    nickname: string;
-  };
 }

--- a/src/types/comments.ts
+++ b/src/types/comments.ts
@@ -1,12 +1,22 @@
-export interface Comment {
-  id: string;
-  content: string;
+export interface User {
+  id: number;
+  nickname: string;
+  email: string;
+  profileImageUrl: string | null;
+  isActive: boolean;
   createdAt: string;
   updatedAt: string;
-  author: {
-    id: string;
+}
+
+export interface Comment {
+  id: number;
+  content: string;
+  createdAt: string;
+  user?: {
     nickname: string;
   };
-  parentId: string | null;
+  userDto?: {
+    nickname: string;
+  };
   replies: Comment[];
 }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -2,7 +2,7 @@ export interface BasePost {
   id: number;
   title: string;
   content: string;
-  thumbnail?: string;
+  thumbnailImgUrl?: string;
   createdAt: string;
   updatedAt: string;
   userId: number;
@@ -34,7 +34,8 @@ export interface StudyPost {
   description: string;
   latitude?: number;
   longitude?: number;
-  status: 'RECRUITING' | 'IN_PROGRESS' | 'CANCELED';
+  address?: string;
+  status: 'RECRUITING' | 'IN_PROGRESS' | 'CLOSED' | 'CANCELED';
   thumbnailImgUrl: string | null;
   maxParticipants: number;
   currentParticipants: number;


### PR DESCRIPTION
### 변경사항
- 스터디 신청 상태 변경 API 파라미터명을 `status`에서 `newStatus`로 수정
- 스터디 모집글 상태값 체계 변경 (RECRUITING, CLOSED, CANCELED)
- 모집 마감 시 백엔드 자동 처리로 변경
**AS-IS**
대댓글 작성, 스터디 신청 및 신청 상태 변경, 모집글 상태값, 모집 마감 처리 등의 백엔드 서버 api 와 연동 되지 않음
모집 마감 처리를 프론트 코드로 시도중이었음
**TO-BE**
대댓글 작성
- 수정된 api 명세서에 맞게 변경

스터디 신청 상태 변경 API
- 파라미터명 수정: `status` → `newStatus`
- 관련 API 라우트 핸들러 수정

스터디 모집글 상태값 체계 변경
- STATUS_DISPLAY 매핑 수정
- UI 텍스트 수정 (모집 완료, 모집 취소 등)

모집 마감 기능 단순화
   - 백엔드 자동 처리 반영

### 테스트
- [x] 대댓글, 스터디 신청 및 수락/거절 기능 정상 동작
- [x] 모집 마감 시 상태 변경 정상 반영
- [x] 모집글 상태에 따른 UI 표시 확인