### PR TITLE
fix: 네이버 소셜 로그인, 회원탈퇴, 마이페이지 게시글 불러오기 구현, 미들웨어 및 쿠키 관련 에러 해결

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,12 +6,15 @@
     "source.fixAll.eslint": "always"
   },
   "cSpell.words": [
+    "compoenets",
     "daisyui",
     "kakao",
     "mypage",
     "Naver",
     "signin",
     "signup",
+    "sockjs",
+    "stompjs",
     "studyroom",
     "Sutdy",
     "tailwindcss",

--- a/src/app/api/auth/sign-in/naver/route.ts
+++ b/src/app/api/auth/sign-in/naver/route.ts
@@ -1,9 +1,3 @@
-// import { NextRequest, NextResponse } from 'next/server';
-
-// export const GET = async (req: NextRequest) => {
-//   const kakaoAuthURL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=${process.env.KAKAO_REDIRECT_URI}`;
-//   return NextResponse.redirect(kakaoAuthURL);
-// };
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 
@@ -20,7 +14,7 @@ export const POST = async (request: NextRequest) => {
 
   try {
     const response = await axios.post(
-      `${process.env.API_URL}/auth/sign-in/kakao`,
+      `${process.env.API_URL}/auth/sign-in/naver`,
       { code },
       {
         headers: {
@@ -31,7 +25,7 @@ export const POST = async (request: NextRequest) => {
 
     if (response.status === 200) {
       const { accessToken, refreshToken } = response.data;
-      const res = NextResponse.json({ message: '로그인 성공' });
+      const res = NextResponse.json({ message: '네이버 로그인 성공' });
       const apiUrl = process.env.API_URL;
 
       if (!apiUrl) {
@@ -54,7 +48,7 @@ export const POST = async (request: NextRequest) => {
   } catch (error: any) {
     if (error.response) {
       const { status } = error.response;
-      return NextResponse.json('카카오 로그인에 실패했습니다.', { status });
+      return NextResponse.json('네이버 로그인에 실패했습니다.', { status });
     }
     return NextResponse.json(
       { message: '네트워크 오류가 발생했습니다.' },

--- a/src/app/api/auth/sign-out/route.ts
+++ b/src/app/api/auth/sign-out/route.ts
@@ -4,6 +4,8 @@ import { deleteCookie } from '@/utils/cookies';
 import { cookies } from 'next/headers';
 
 export const POST = async (req: NextRequest) => {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
   try {
     await axios.post(
       `${process.env.API_URL}/auth/sign-out`,
@@ -11,15 +13,21 @@ export const POST = async (req: NextRequest) => {
       {
         headers: {
           'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
         },
       },
     );
     const res = NextResponse.json({ message: '로그아웃 성공' });
 
-    deleteCookie(res, 'accessToken');
-    deleteCookie(res, 'refreshToken');
+    // deleteCookie(res, 'accessToken');
+    // deleteCookie(res, 'refreshToken');
+    res.cookies.set('accessToken', '', { maxAge: 0 });
+    res.cookies.set('refreshToken', '', { maxAge: 0 });
 
-    return res;
+    return NextResponse.json(
+      { message: '로그아웃 성공' },
+      { headers: res.headers },
+    );
   } catch (error: any) {
     if (error.response) {
       const { status, data } = error.response;

--- a/src/app/api/auth/token-reissue/route.ts
+++ b/src/app/api/auth/token-reissue/route.ts
@@ -5,8 +5,9 @@ import jwt from 'jsonwebtoken';
 import { setCookie } from '@/utils/cookies';
 
 export const POST = async (req: NextRequest) => {
-  const cookiesList = await cookies();
-  const refreshToken = cookiesList.get('refreshToken')?.value;
+  // const cookiesList = await cookies();
+  // const refreshToken = cookiesList.get('refreshToken')?.value;
+  const { refreshToken } = await req.json();
 
   if (!refreshToken) {
     return NextResponse.json(
@@ -15,12 +16,10 @@ export const POST = async (req: NextRequest) => {
     );
   }
 
-  const { email } = await req.json();
-
   try {
     const response = await axios.post(
       `${process.env.API_URL}/auth/token-reissue`, // 백엔드 API 실제 경로
-      { email, refreshToken },
+      { refreshToken },
       {
         headers: { 'Content-Type': 'application/json' },
       },
@@ -44,7 +43,11 @@ export const POST = async (req: NextRequest) => {
       const res = NextResponse.json({ message: '토큰 갱신 성공' });
 
       setCookie(res, 'accessToken', accessToken, accessTokenMaxAge);
-      return res;
+      res.headers.set('Authorization', `Bearer ${accessToken}`);
+      return (
+        NextResponse.json({ message: '토큰 갱신 성공' }),
+        { headers: res.headers }
+      );
     }
     return NextResponse.json(response.data, { status: response.status });
   } catch (error: any) {

--- a/src/app/api/auth/withdrawal/route.ts
+++ b/src/app/api/auth/withdrawal/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+import { deleteCookie } from '@/utils/cookies';
+import { cookies } from 'next/headers';
+
+export const POST = async (req: NextRequest) => {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  try {
+    await axios.post(
+      `${process.env.API_URL}/auth/withdrawal`,
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    const res = NextResponse.json({ message: '회원 탈퇴 성공' });
+
+    // deleteCookie(res, 'accessToken');
+    // deleteCookie(res, 'refreshToken');
+    res.cookies.set('accessToken', '', { maxAge: 0 });
+    res.cookies.set('refreshToken', '', { maxAge: 0 });
+
+    return NextResponse.json(
+      { message: '회원 탈퇴 성공' },
+      { headers: res.headers },
+    );
+  } catch (error: any) {
+    if (error.response) {
+      const { status, data } = error.response;
+      return NextResponse.json(data, { status });
+    }
+
+    return NextResponse.json(
+      { message: '네트워크 오류가 발생했습니다.' },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/info-posts/author/[userId]/route.ts
+++ b/src/app/api/info-posts/author/[userId]/route.ts
@@ -2,17 +2,25 @@ import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 
 export const GET = async (
-  req: NextRequest,
+  request: NextRequest,
   { params }: { params: { userId: string } },
 ) => {
   const { userId } = await params;
+
   try {
     const response = await axios.get(
-      `${process.env.API_URL}/study/author/${userId}`,
+      `${process.env.API_URL}/info-posts/author/${userId}?page=1`, // 백엔드 서버 URL
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
     );
 
     if (response.status === 200) {
-      return NextResponse.json(response.data, { status: response.status });
+      if (response.status === 200) {
+        return NextResponse.json(response.data, { status: response.status });
+      }
     }
   } catch (error: any) {
     if (error.response) {
@@ -20,6 +28,7 @@ export const GET = async (
       return NextResponse.json(data, { status });
     }
 
+    // 네트워크 오류 처리
     return NextResponse.json(
       { message: '네트워크 오류가 발생했습니다.' },
       { status: 500 },

--- a/src/app/api/mock/auth/sign-out/route.ts
+++ b/src/app/api/mock/auth/sign-out/route.ts
@@ -3,13 +3,29 @@ import { NextResponse } from 'next/server';
 export const POST = async () => {
   const response = NextResponse.json({ message: 'Mock 로그아웃 성공' });
 
+  // response.cookies.set('accessToken', '', {
+  //   path: '/',
+  //   maxAge: 0,
+  // });
+  // response.cookies.set('refreshToken', '', {
+  //   path: '/',
+  //   maxAge: 0, // 쿠키 삭제
+  // });
+
   response.cookies.set('accessToken', '', {
-    path: '/',
-    maxAge: 0,
+    path: '/', // 쿠키의 경로를 지정
+    maxAge: 0, // 쿠키 만료 시간 0초로 설정하여 삭제
+    httpOnly: true, // 보안상의 이유로 JavaScript에서 접근 불가
+    secure: false, // HTTPS 환경에서만 쿠키를 설정하려면 true로 설정 (로컬 개발 환경에서는 false)
+    sameSite: 'lax', // CSRF 보호를 위한 sameSite 옵션
   });
+
   response.cookies.set('refreshToken', '', {
     path: '/',
-    maxAge: 0, // 쿠키 삭제
+    maxAge: 0,
+    httpOnly: true,
+    secure: false,
+    sameSite: 'lax',
   });
 
   return response;

--- a/src/app/api/qna-posts/author/[userId]/route.ts
+++ b/src/app/api/qna-posts/author/[userId]/route.ts
@@ -2,17 +2,25 @@ import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 
 export const GET = async (
-  req: NextRequest,
+  request: NextRequest,
   { params }: { params: { userId: string } },
 ) => {
   const { userId } = await params;
+
   try {
     const response = await axios.get(
-      `${process.env.API_URL}/study/author/${userId}`,
+      `${process.env.API_URL}/qna-posts/author/${userId}`, // 백엔드 서버 URL
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
     );
 
     if (response.status === 200) {
-      return NextResponse.json(response.data, { status: response.status });
+      if (response.status === 200) {
+        return NextResponse.json(response.data, { status: response.status });
+      }
     }
   } catch (error: any) {
     if (error.response) {
@@ -20,6 +28,7 @@ export const GET = async (
       return NextResponse.json(data, { status });
     }
 
+    // 네트워크 오류 처리
     return NextResponse.json(
       { message: '네트워크 오류가 발생했습니다.' },
       { status: 500 },

--- a/src/app/api/study-posts/author/[userId]/route.ts
+++ b/src/app/api/study-posts/author/[userId]/route.ts
@@ -8,7 +8,7 @@ export const GET = async (
   const { userId } = await params;
   try {
     const response = await axios.get(
-      `${process.env.API_URL}/study/author/${userId}`,
+      `${process.env.API_URL}/study-posts/author/${userId}`,
     );
 
     if (response.status === 200) {

--- a/src/app/api/users/[userId]/profile-image/route.ts
+++ b/src/app/api/users/[userId]/profile-image/route.ts
@@ -25,7 +25,8 @@ export const POST = async (
     );
 
     if (response.status === 200) {
-      const updatedUserInfo = response.data;
+      const { isActive, createdAt, updatedAt, ...updatedUserInfo } =
+        response.data;
       console.log('response data:', updatedUserInfo);
       return NextResponse.json(updatedUserInfo, { status: response.status });
     }
@@ -58,7 +59,8 @@ export const DELETE = async (
     );
 
     if (response.status === 200) {
-      const updatedUserInfo = response.data;
+      const { isActive, createdAt, updatedAt, ...updatedUserInfo } =
+        response.data;
       return NextResponse.json(updatedUserInfo, { status: response.status });
     }
   } catch (error: any) {

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
-import { cookies } from 'next/headers';
 
 export const PUT = async (
   request: NextRequest,
@@ -28,7 +27,9 @@ export const PUT = async (
     );
 
     if (response.status === 200) {
-      const updatedUserInfo = response.data;
+      const { isActive, createdAt, updatedAt, ...updatedUserInfo } =
+        response.data;
+
       return NextResponse.json(updatedUserInfo, { status: response.status });
     }
   } catch (error: any) {

--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -1,6 +1,7 @@
 import { useGroupChat } from '@/hooks/useGroupChat';
 import MessageInput from './MessageInput';
 import { useEffect, useRef } from 'react';
+import { useAuthStore } from '@/store/authStore';
 interface ChatRoomProps {
   chatRoomId: string;
 }
@@ -8,6 +9,8 @@ interface ChatRoomProps {
 const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
   const { messages, chatState, sendMessage, connect } =
     useGroupChat(chatRoomId);
+  const { userInfo } = useAuthStore();
+  // const userId = userInfo?.id;
   const userId = 'user1';
   const chatContainerRef = useRef<HTMLDivElement>(null);
 

--- a/src/app/community/study/components/StudyCard.tsx
+++ b/src/app/community/study/components/StudyCard.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
-import { StudyPost } from '@/types/study';
+import { StudyPost } from '@/types/post';
 
 interface StudyCardProps {
   post: StudyPost;
@@ -12,7 +12,10 @@ export function StudyCard({ post }: StudyCardProps) {
   const router = useRouter();
 
   return (
-    <div className="card bg-base-100 shadow-xl">
+    <div
+      className="card bg-base-100 shadow-xl cursor-pointer"
+      onClick={() => router.push(`/community/study/${post.id}`)}
+    >
       <figure className="px-4 pt-4">
         <img
           src={post.thumbnailImgUrl || '/default-study-thumbnail.png'}
@@ -52,12 +55,7 @@ export function StudyCard({ post }: StudyCardProps) {
           </div>
         </div>
         <div className="card-actions justify-end mt-4">
-          <button
-            className="btn btn-primary btn-sm"
-            onClick={() => router.push(`/community/study/${post.id}`)}
-          >
-            상세보기
-          </button>
+          <button className="btn btn-primary btn-sm">상세보기</button>
         </div>
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default async function RootLayout({
         <Providers>
           {process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' && <MSWProvider />}
           <div className="flex flex-col min-h-screen">
-            <Header initialSignedIn={isSignedIn} />
+            <Header />
             <main className="flex-1 container mx-auto px-4 py-8">
               {children}
             </main>

--- a/src/app/middlewares/pathConstants.ts
+++ b/src/app/middlewares/pathConstants.ts
@@ -2,6 +2,7 @@ export const IGNORED_PATHS = [
   '/api/auth/sign-in',
   '/api/mock/auth/sign-in',
   '/api/auth/sign-in/kakao',
+  '/api/auth/sign-in/naver',
   '/community/study/*',
   '/community/qna/*',
   '/community/info/*',

--- a/src/app/middlewares/processAccessToken.ts
+++ b/src/app/middlewares/processAccessToken.ts
@@ -3,8 +3,12 @@ import { NextRequest, NextResponse } from 'next/server';
 const processAccessToken = (request: NextRequest, accessToken: string) => {
   console.log('accessToken 존재:', accessToken);
 
+  console.log(`미들웨어 pathname: ${request.nextUrl.pathname}`);
+
   // API 서버의 URL로 요청을 리라이트
-  const apiUrl = `${process.env.SERVER_URL}/${request.nextUrl.pathname}`;
+  const pathname = request.nextUrl.pathname;
+  const search = request.nextUrl.search;
+  const apiUrl = `${process.env.SERVER_URL}${pathname}${search}`;
   const headers = new Headers(request.headers);
 
   // 기존의 Authorization 헤더를 추가

--- a/src/app/middlewares/processRefreshToken.ts
+++ b/src/app/middlewares/processRefreshToken.ts
@@ -1,10 +1,88 @@
 import { NextRequest, NextResponse } from 'next/server';
-import handleRedirectToSignIn from './handleRedirectToSignIn';
+import axios from 'axios';
+import jwt from 'jsonwebtoken';
+import { setCookie } from '@/utils/cookies';
 
-const processRefreshToken = (request: NextRequest, accessToken: string) => {
+// const processRefreshToken = (request: NextRequest, refreshToken: string) => {
+//   console.log('accessToken 없음');
+//   const refreshRoute = new URL('/api/auth/token-reissue', request.url);
+//   const headers = new Headers({ 'Content-Type': 'application/json' });
+//   return NextResponse.rewrite(refreshRoute, { headers: headers });
+// };
+
+// export default processRefreshToken;
+
+const processRefreshToken = async (
+  request: NextRequest,
+  refreshToken: string,
+) => {
   console.log('accessToken 없음');
-  const refreshRoute = new URL('/api/auth/token-reissue', request.url);
-  return NextResponse.rewrite(refreshRoute);
+  // const refreshRoute = new URL('/api/auth/token-reissue', request.url);
+  // const headers = new Headers({ 'Content-Type': 'application/json' });
+  // return NextResponse.rewrite(refreshRoute, { headers: headers });
+
+  try {
+    const response = await axios.post(
+      `${process.env.API_URL}/auth/token-reissue`, // 백엔드 API 실제 경로
+      { refreshToken },
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+
+    if (response.status === 200) {
+      const { accessToken } = response.data;
+
+      const decodedAccessToken = jwt.decode(accessToken) as { exp: number };
+      if (!decodedAccessToken || !decodedAccessToken.exp) {
+        throw new Error('액세스토큰 exp 클레임이 없습니다.');
+      }
+
+      const currentTime = Math.trunc(Date.now() / 1000);
+      const bufferTime = 10;
+      const accessTokenMaxAge = Math.max(
+        decodedAccessToken.exp - currentTime - bufferTime,
+        0,
+      );
+
+      const res = NextResponse.json({ message: '토큰 갱신 성공' });
+
+      const setCookie = (
+        res: NextResponse,
+        name: string,
+        value: string,
+        maxAge: number,
+      ) => {
+        res.cookies.set(name, value, {
+          // secure: process.env.NODE_ENV === 'production', // https 일때만 전송
+          httpOnly: true, // 클라이언트 자바스크립트에서는 접근 불가(보안상의 이유)
+          secure: false,
+          path: '/', // 쿠키의 유효 경로
+          sameSite: 'strict',
+          maxAge,
+        });
+
+        console.log(`쿠키 설정됨: ${name} = ${value}`);
+      };
+
+      setCookie(res, 'accessToken', accessToken, accessTokenMaxAge);
+      res.headers.set('Authorization', `Bearer ${accessToken}`);
+
+      // return (
+      //   NextResponse.json({ message: '토큰 갱신 성공' }),
+      //   { headers: res.headers }
+      // );
+      return res;
+    }
+    return NextResponse.json(response.data, { status: response.status });
+  } catch (error: any) {
+    if (axios.isAxiosError(error) && error.response) {
+      return NextResponse.json(error.response.data, {
+        status: error.response.status,
+      });
+    }
+    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+  }
 };
 
 export default processRefreshToken;

--- a/src/app/mypage/components/MyInfoPostCard.tsx
+++ b/src/app/mypage/components/MyInfoPostCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { BasePost } from '@/types/post';
+import { useRouter } from 'next/navigation';
+import dayjs from 'dayjs';
+
+interface MyPostCardProps {
+  post: BasePost;
+}
+
+const MyInfoPostCard = ({ post }: MyPostCardProps) => {
+  const router = useRouter();
+
+  const formatDate = (date: string) => {
+    return dayjs(date).format('YYYY-MM-DD HH:mm');
+  };
+
+  return (
+    <div
+      className="card bg-base-100 shadow-xl cursor-pointer"
+      onClick={() => router.push(`/community/info/${post.id}`)}
+    >
+      <figure className="px-4 pt-4">
+        <img
+          // src={post?.thumbnailImgUrl || '/default-study-thumbnail.png'}
+          src="/default-study-thumbnail.png"
+          alt={post.title}
+          className="rounded-xl h-48 w-full object-cover"
+        />
+      </figure>
+      <div className="card-body">
+        <h2 className="card-title text-lg">{post.title}</h2>
+        <div className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span>정보 공유</span>
+          </div>
+          <div className="flex justify-between">
+            <span>내용:</span>
+            <span>{post.content}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>작성일:</span>
+            <span>{formatDate(post.createdAt)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>수정일:</span>
+            <span>{formatDate(post.updatedAt)}</span>
+          </div>
+        </div>
+      </div>
+      <div className="card-actions justify-end mt-4">
+        <button className="btn btn-primary btn-sm">상세보기</button>
+      </div>
+    </div>
+  );
+};
+
+export default MyInfoPostCard;

--- a/src/app/mypage/components/MyQnAPostCard.tsx
+++ b/src/app/mypage/components/MyQnAPostCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { BasePost } from '@/types/post';
+import { useRouter } from 'next/navigation';
+import dayjs from 'dayjs';
+
+interface MyPostCardProps {
+  post: BasePost;
+}
+
+const MyQnAPostCard = ({ post }: MyPostCardProps) => {
+  const router = useRouter();
+
+  const formatDate = (date: string) => {
+    return dayjs(date).format('YYYY-MM-DD HH:mm');
+  };
+
+  return (
+    <div
+      className="card bg-base-100 shadow-xl cursor-pointer"
+      onClick={() => router.push(`/community/qna/${post.id}`)}
+    >
+      <figure className="px-4 pt-4">
+        <img
+          // src={post?.thumbnailImgUrl || '/default-study-thumbnail.png'}
+          src="/default-study-thumbnail.png"
+          alt={post.title}
+          className="rounded-xl h-48 w-full object-cover"
+        />
+      </figure>
+      <div className="card-body">
+        <h2 className="card-title text-lg">{post.title}</h2>
+        <div className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span>정보 공유</span>
+          </div>
+          <div className="flex justify-between">
+            <span>내용:</span>
+            <span>{post.content}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>작성일:</span>
+            <span>{formatDate(post.createdAt)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>수정일:</span>
+            <span>{formatDate(post.updatedAt)}</span>
+          </div>
+        </div>
+      </div>
+      <div className="card-actions justify-end mt-4">
+        <button className="btn btn-primary btn-sm">상세보기</button>
+      </div>
+    </div>
+  );
+};
+
+export default MyQnAPostCard;

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import dayjs from 'dayjs';
+import { StudyPost } from '@/types/post';
+import { useAuthStore } from '@/store/authStore';
+
+interface MyStudyCardProps {
+  post: MyStudyCardData;
+}
+
+export interface MyStudyCardData {
+  id: number;
+  studyName: string;
+  subject: string;
+  difficulty: string;
+  dayType: string[]; // 요일
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+  status: string;
+  studyPostId: number;
+  studyLeaderId: number;
+  totalParticipants: number;
+  thumbnailImgUrl?: string; // 썸네일 이미지 URL (optional)
+}
+
+const MyStudyCard = ({ post }: MyStudyCardProps) => {
+  const router = useRouter();
+  const { userInfo } = useAuthStore();
+
+  // 시간에서 :00을 제거하는 함수
+  const formatTime = (time: string) => {
+    return time.slice(0, 5);
+  };
+
+  return (
+    <div
+      className="card bg-base-100 shadow-xl cursor-pointer"
+      onClick={() => router.push(`/community/study/${post.studyPostId}`)}
+    >
+      <figure className="px-4 pt-4">
+        <img
+          src={post.thumbnailImgUrl || '/default-study-thumbnail.png'}
+          alt={post.studyName}
+          className="rounded-xl h-48 w-full object-cover"
+        />
+      </figure>
+      <div className="card-body">
+        <h2 className="card-title text-lg items-center">
+          {post.studyName}
+          {userInfo?.id === post.studyLeaderId && (
+            <span className="badge badge-primary ml-2">스터디장</span>
+          )}
+        </h2>
+        <div className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span>상태:</span>
+            <span>{post.status}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>주제:</span>
+            <span>{post.subject}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>난이도:</span>
+            <span>{post.difficulty}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>요일:</span>
+            <span>{post.dayType?.join(', ') || '없음'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>기간:</span>
+            <span>
+              {dayjs(post.startDate).format('MM.DD')} ~{' '}
+              {dayjs(post.endDate).format('MM.DD')}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span>시간:</span>
+            <span>
+              {formatTime(post.startTime)} ~ {formatTime(post.endTime)}
+            </span>
+          </div>
+        </div>
+        <div className="card-actions justify-end mt-4">
+          <button
+            className="btn btn-primary btn-sm"
+            onClick={e => {
+              e.stopPropagation();
+              router.push(`/chat/chatRoomId/${post.id}`);
+            }}
+          >
+            채팅
+          </button>
+          <button
+            className="btn btn-primary btn-sm"
+            onClick={e => {
+              e.stopPropagation();
+              router.push(`/community/study/${post.id}`);
+            }}
+          >
+            스터디룸
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyStudyCard;

--- a/src/app/mypage/components/MyStudyView.tsx
+++ b/src/app/mypage/components/MyStudyView.tsx
@@ -1,90 +1,340 @@
 'use client';
 
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import dayjs from 'dayjs';
+import { StudyPost } from '@/types/post';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useAuthStore } from '@/store/authStore';
+import MyStudyCard from './MyStudyCard';
+import { MyStudyCardData } from './MyStudyCard';
+import { StudyCard } from '@/app/community/study/components/StudyCard';
+import MyInfoPostCard from './MyInfoPostCard';
+import MyQnAPostCard from './MyQnAPostCard';
+import { BasePost } from '@/types/post';
 
-interface Study {
-  id: string;
-  name: string;
-  thumbnail?: string; // 썸네일 추가
-  description?: string; // 설명 추가
+interface MyStudyProps {
+  post: StudyPost;
 }
 
-interface MyPageProps {
-  studies: Study[];
-}
-
-const MyStudyView = ({ studies }: MyPageProps) => {
+const MyStudyView = () => {
+  const { userInfo } = useAuthStore();
   const [activeTab, setActiveTab] = useState('myStudy'); // 기본값을 'myStudy'
+  const [myStudies, setMyStudies] = useState<MyStudyCardData[]>([]);
+  const [myStudyPosts, setMyStudyPosts] = useState<StudyPost[]>([]);
+  const [myInfoPosts, setMyInfoPosts] = useState<BasePost[]>([]);
+  const [myQnAPosts, setMyQnAPosts] = useState<BasePost[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleMyStudyTabClick = () => {
-    setActiveTab('');
+  useEffect(() => {
+    // 마이페이지가 처음 로드될 때 'myStudy' 탭 클릭 상태
+    handleTabClick('myStudy');
+  }, []);
+
+  const handleMyStudyTabClick = async () => {
+    try {
+      if (userInfo?.id) {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/study/author/${userInfo?.id}`,
+        );
+        if (response.status === 200 && response.data) {
+          setMyStudies(response.data.content);
+        }
+      }
+    } catch (error: any) {
+      if (error.response) {
+        const { status, data } = error.response;
+        console.log('error:' + error.response);
+        const message =
+          data?.errorMessage ||
+          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        setError(message);
+      } else {
+        setError('내가 속한 스터디 목록을 불러오는 데 실패했습니다.');
+      }
+    }
+    const data = {
+      content: [
+        {
+          id: 25,
+          studyName: '코테',
+          subject: 'JOB_PREPARATION',
+          difficulty: 'HIGH',
+          dayType: ['화', '목'],
+          startDate: '2024-12-04',
+          endDate: '2024-12-22',
+          startTime: '19:00:00',
+          endTime: '21:00:00',
+          meetingType: 'HYBRID',
+          status: 'PENDING',
+          studyPostId: 97,
+          studyLeaderId: 11,
+          totalParticipants: 2,
+        },
+        {
+          id: 24,
+          studyName: '코테',
+          subject: 'JOB_PREPARATION',
+          difficulty: 'HIGH',
+          dayType: ['화', '목'],
+          startDate: '2024-12-04',
+          endDate: '2024-12-22',
+          startTime: '19:00:00',
+          endTime: '21:00:00',
+          meetingType: 'HYBRID',
+          status: 'PENDING',
+          studyPostId: 98,
+          studyLeaderId: 11,
+          totalParticipants: 2,
+        },
+        {
+          id: 23,
+          studyName: '코테',
+          subject: 'JOB_PREPARATION',
+          difficulty: 'HIGH',
+          dayType: ['화', '목'],
+          startDate: '2024-12-04',
+          endDate: '2024-12-22',
+          startTime: '19:00:00',
+          endTime: '21:00:00',
+          meetingType: 'HYBRID',
+          status: 'PENDING',
+          studyPostId: 96,
+          studyLeaderId: 11,
+          totalParticipants: 2,
+        },
+      ],
+      pageable: {
+        pageNumber: 0,
+        pageSize: 20,
+        sort: {
+          empty: true,
+          sorted: false,
+          unsorted: true,
+        },
+        offset: 0,
+        paged: true,
+        unpaged: false,
+      },
+      last: true,
+      totalPages: 1,
+      totalElements: 3,
+      first: true,
+      size: 20,
+      number: 0,
+      sort: {
+        empty: true,
+        sorted: false,
+        unsorted: true,
+      },
+      numberOfElements: 3,
+      empty: false,
+    };
+
+    // setMyStudies(data.content);
+  };
+
+  const handleMyStudyPostTabClick = async () => {
+    try {
+      if (userInfo?.id) {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/study-posts/author/${userInfo?.id}`,
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+        if (response.status === 200 && response.data) {
+          setMyStudyPosts(response.data.content);
+          console.log('나의 스터디 모집 글 불러오기 성공했습니다.');
+        }
+      }
+    } catch (error: any) {
+      if (error.response) {
+        const { status, data } = error.response;
+        console.log('error:' + error.response);
+        const message =
+          data?.errorMessage ||
+          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        setError(message);
+      } else {
+        setError('나의 스터디 모집 글 목록을 불러오는 데 실패했습니다.');
+      }
+    }
+  };
+
+  const handleMyInfoPostTabClick = async () => {
+    try {
+      if (userInfo?.id) {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/info-posts/author/${userInfo?.id}`,
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+        if (response.status === 200 && response.data) {
+          setMyInfoPosts(response.data.content);
+          console.log('나의 정보 공유 게시글 불러오기 성공했습니다.');
+        }
+      }
+    } catch (error: any) {
+      if (error.response) {
+        const { status, data } = error.response;
+        console.log('error:' + error.response.data.errorMessage);
+        const message =
+          data?.errorMessage ||
+          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        setError(message);
+      } else {
+        setError('나의 정보 공유 게시글 목록을 불러오는 데 실패했습니다.');
+      }
+    }
+  };
+
+  const handleMyQnAPostTabClick = async () => {
+    try {
+      if (userInfo?.id) {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/qna-posts/author/${userInfo?.id}`,
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+        if (response.status === 200 && response.data) {
+          setMyQnAPosts(response.data.content);
+          console.log('나의 Q&A 게시글 불러오기 성공했습니다.');
+        }
+      }
+    } catch (error: any) {
+      if (error.response) {
+        const { status, data } = error.response;
+        console.log('error:' + error.response);
+        const message =
+          data?.errorMessage ||
+          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        setError(message);
+      } else {
+        setError('나의 Q&A 게시글 목록을 불러오는 데 실패했습니다.');
+      }
+    }
   };
 
   // 탭 클릭 시 해당 탭의 내용을 보여주는 함수
   const renderTabContent = () => {
+    if (error) {
+      return <p className="col-span-full text-center text-red-500">{error}</p>;
+    }
+
     switch (activeTab) {
       case 'myStudy':
         return (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {studies.length === 0 ? (
+            {myStudies.length === 0 ? (
               <p className="col-span-full text-center text-gray-500">
-                스터디 목록이 없습니다.
+                내가 속한 스터디가 없습니다.
               </p>
             ) : (
-              studies.map(study => (
-                <div
-                  key={study.id}
-                  className="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow"
-                >
-                  <figure className="px-4 pt-4">
-                    <img
-                      src={study.thumbnail || '/default-study-thumbnail.png'}
-                      alt={study.name}
-                      className="rounded-xl h-48 w-full object-cover"
-                    />
-                  </figure>
-                  <div className="card-body">
-                    <h2 className="card-title text-lg font-bold">
-                      {study.name}
-                    </h2>
-                    <p className="text-sm text-base-content/70 mt-2">
-                      {study.description || '스터디 설명이 없습니다.'}
-                    </p>
-                    <div className="card-actions justify-end mt-4">
-                      <button className="btn btn-primary btn-sm">
-                        채팅방 열기
-                      </button>
-                      <button className="btn btn-secondary btn-sm">
-                        스터디룸 보기
-                      </button>
-                    </div>
-                  </div>
-                </div>
+              myStudies.map(myStudy => (
+                <MyStudyCard key={myStudy.studyPostId} post={myStudy} />
+                // <div
+                //   key={myStudy.id}
+                //   className="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow"
+                // >
+                //   <figure className="px-4 pt-4">
+                //     <img
+                //       src={myStudy.thumbnail || '/default-study-thumbnail.png'}
+                //       alt={myStudy.name}
+                //       className="rounded-xl h-48 w-full object-cover"
+                //     />
+                //   </figure>
+                //   <div className="card-body">
+                //     <h2 className="card-title text-lg font-bold">
+                //       {study.name}
+                //     </h2>
+                //     <p className="text-sm text-base-content/70 mt-2">
+                //       {study.description || '스터디 설명이 없습니다.'}
+                //     </p>
+                //     <div className="card-actions justify-end mt-4">
+                //       <button className="btn btn-primary btn-sm">
+                //         채팅방 열기
+                //       </button>
+                //       <button className="btn btn-secondary btn-sm">
+                //         스터디룸 보기
+                //       </button>
+                //     </div>
+                //   </div>
+                // </div>
               ))
             )}
           </div>
         );
-      case 'study':
+      case 'myStudyPost':
         return (
-          <div>
-            <p>나의 스터디 모집글 탭 내용</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {myStudyPosts.length === 0 ? (
+              <p className="col-span-full text-center text-gray-500">
+                작성한 스터디 모집 글이 없습니다.
+              </p>
+            ) : (
+              myStudyPosts.map(myStudyPost => (
+                <StudyCard key={myStudyPost.id} post={myStudyPost} />
+              ))
+            )}
           </div>
         );
-      case 'info':
-        return <p>나의 정보공유 탭 내용</p>;
-      case 'qna':
-        return <p>나의 Q&A 탭 내용</p>;
+      case 'myInfoPost':
+        return (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {myInfoPosts.length === 0 ? (
+              <p className="col-span-full text-center text-gray-500">
+                작성한 정보 공유 게시글이 없습니다.
+              </p>
+            ) : (
+              myInfoPosts.map(myInfoPost => (
+                <MyInfoPostCard key={myInfoPost.id} post={myInfoPost} />
+              ))
+            )}
+          </div>
+        );
+
+      case 'myQnAPost':
+        return (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {myQnAPosts.length === 0 ? (
+              <p className="col-span-full text-center text-gray-500">
+                작성한 Q&A 게시글이 없습니다.
+              </p>
+            ) : (
+              myQnAPosts.map(myQnAPost => (
+                <MyQnAPostCard key={myQnAPost.id} post={myQnAPost} />
+              ))
+            )}
+          </div>
+        );
       default:
         return <p>기타 탭에 대한 내용</p>;
     }
   };
 
+  // 탭 클릭 핸들러
+  const handleTabClick = (tab: string) => {
+    setActiveTab(tab);
+    setError(null);
+    if (tab === 'myStudy') {
+      handleMyStudyTabClick();
+    } else if (tab === 'myStudyPost') {
+      handleMyStudyPostTabClick();
+    } else if (tab === 'myInfoPost') {
+      handleMyInfoPostTabClick();
+    } else if (tab === 'myQnAPost') {
+      handleMyQnAPostTabClick();
+    }
+  };
+
   return (
     <div className="p-6 space-y-6">
-      {/* DaisyUI 탭 구조 */}
       <div role="tablist" className="tabs tabs-lifted">
         <button
-          onClick={() => setActiveTab('myStudy')}
+          onClick={() => handleTabClick('myStudy')}
           className={`tab tab-lg ${
             activeTab === 'myStudy' ? 'tab-active shadow-lg font-bold' : ''
           }`}
@@ -92,32 +342,30 @@ const MyStudyView = ({ studies }: MyPageProps) => {
           내가 속한 스터디
         </button>
         <button
-          onClick={() => setActiveTab('study')}
+          onClick={() => handleTabClick('myStudyPost')}
           className={`tab tab-lg ${
-            activeTab === 'study' ? 'tab-active shadow-lg font-bold' : ''
+            activeTab === 'myStudyPost' ? 'tab-active shadow-lg font-bold' : ''
           }`}
         >
           나의 스터디 모집글
         </button>
         <button
-          onClick={() => setActiveTab('info')}
+          onClick={() => handleTabClick('myInfoPost')}
           className={`tab tab-lg ${
-            activeTab === 'info' ? 'tab-active shadow-lg font-bold' : ''
+            activeTab === 'myInfoPost' ? 'tab-active shadow-lg font-bold' : ''
           }`}
         >
           나의 정보 공유
         </button>
         <button
-          onClick={() => setActiveTab('qna')}
+          onClick={() => handleTabClick('myQnAPost')}
           className={`tab tab-lg ${
-            activeTab === 'qna' ? 'tab-active shadow-lg font-bold' : ''
+            activeTab === 'myQnAPost' ? 'tab-active shadow-lg font-bold' : ''
           }`}
         >
           나의 Q&A
         </button>
       </div>
-
-      {/* 탭 내용 */}
       <div className="p-4 bg-base-200 rounded-lg shadow-md border-t-4 border-primary">
         {renderTabContent()}
       </div>

--- a/src/app/oauth2/callback/naver/page.tsx
+++ b/src/app/oauth2/callback/naver/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import CustomAlert from '@/components/common/Alert';
 
-const KakaoCallbackPage = () => {
+const NaverCallbackPage = () => {
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
   console.log(`code: ${code}`);
@@ -16,9 +16,9 @@ const KakaoCallbackPage = () => {
   const [alertMessage, setAlertMessage] = useState('');
 
   useEffect(() => {
-    const sendKakaoAuthCode = async () => {
+    const sendNaverAuthCode = async () => {
       if (!code) {
-        setAlertMessage('카카오 인증 코드가 없습니다.');
+        setAlertMessage('네이버 인증 코드가 없습니다.');
         setShowAlert(true);
         router.push('/signin');
         return;
@@ -26,7 +26,7 @@ const KakaoCallbackPage = () => {
 
       try {
         const response = await axios.post(
-          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/auth/sign-in/kakao`,
+          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/auth/sign-in/naver`,
           {
             code,
           },
@@ -56,7 +56,7 @@ const KakaoCallbackPage = () => {
             setShowAlert(true);
           } else {
             setAlertMessage(
-              '카카오 로그인에 실패했습니다. 다시 시도해 주세요.',
+              '네이버 로그인에 실패했습니다. 다시 시도해 주세요.',
             );
             setShowAlert(true);
           }
@@ -69,7 +69,7 @@ const KakaoCallbackPage = () => {
       }
     };
 
-    sendKakaoAuthCode();
+    sendNaverAuthCode();
   }, [code]);
 
   return (
@@ -84,4 +84,4 @@ const KakaoCallbackPage = () => {
   );
 };
 
-export default KakaoCallbackPage;
+export default NaverCallbackPage;

--- a/src/app/signin/components/SignInForm.tsx
+++ b/src/app/signin/components/SignInForm.tsx
@@ -75,7 +75,18 @@ const SingInPage = () => {
     }
   };
 
-  const handleKakaoButtonClick = async () => {
+  const handleNaverSignInButtonClick = async () => {
+    try {
+      const state = Math.trunc(Math.random() * 1e6) + '';
+      // 네이버 로그인 페이지로 리디렉션
+      const naverAuthURL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.NEXT_PUBLIC_NAVER_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_NAVER_REDIRECT_URI}&state=${state}`;
+      window.location.href = naverAuthURL;
+    } catch (error) {
+      console.error('네이버 로그인 오류:', error);
+    }
+  };
+
+  const handleKakaoSignInButtonClick = async () => {
     try {
       // 카카오 로그인 페이지로 리디렉션
       const kakaoAuthURL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&response_type=code&scope=profile_nickname,account_email`;
@@ -156,6 +167,7 @@ const SingInPage = () => {
         <button
           name="Naver"
           className="flex items-center justify-center w-full btn bg-green-500 hover:bg-green-600 hover:text-white text-sm sm:text-base"
+          onClick={handleNaverSignInButtonClick}
         >
           <SiNaver className="mr-2 text-white" size={16} />
           <span className="font-medium">Naver</span> 로그인
@@ -163,7 +175,7 @@ const SingInPage = () => {
         <button
           name="Kakao"
           className="flex items-center justify-center w-full btn text-yellow-950 bg-yellow-300 hover:bg-yellow-500 hover:text-white text-sm sm:text-base"
-          onClick={handleKakaoButtonClick}
+          onClick={handleKakaoSignInButtonClick}
         >
           <RiKakaoTalkFill className="mr-2 text-yellow-950" size={24} />
           <span className="font-medium">Kakao</span> 로그인

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -84,24 +84,23 @@ const Header = () => {
       console.log('data: ' + data);
 
       const message =
-        data?.message || '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        data?.errorMessage || '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
       if (error.response) {
         if (status === 400) {
           setAlertMessage('로그아웃에 실패했습니다. 다시 시도해 주세요.');
-          setShowAlert(true);
-        } else if (status === 403) {
+        } else if (status === 404) {
           setAlertMessage('사용자를 찾을 수 없습니다.');
-          setShowAlert(true);
         } else {
-          setAlertMessage('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-          setShowAlert(true);
+          setAlertMessage(
+            '서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+          );
         }
       } else {
         setAlertMessage(
           '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',
         );
-        setShowAlert(true);
       }
+      setShowAlert(true);
     } finally {
       setShowConfirm(false);
     }

--- a/src/hooks/useGroupChat.ts
+++ b/src/hooks/useGroupChat.ts
@@ -50,7 +50,7 @@ export const useGroupChat = (chatRoomId: string) => {
 
     try {
       const socket = new SockJS(
-        `${process.env.NEXT_PUBLIC_BACKEND_SOCKET_URL}/ws` as string,
+        `${process.env.NEXT_PUBLIC_CHAT_SOCKET_URL}/ws` as string,
       );
       console.log('SockJS 생성 완료', {
         socketState: socket.readyState, // 0: connecting, 1: open, 2: closing, 3: closed
@@ -127,7 +127,7 @@ export const useGroupChat = (chatRoomId: string) => {
   const loadPreviousMessages = useCallback(async () => {
     try {
       const response = await axios.get(
-        `${process.env.NEXT_PUBLIC_BACKEND_SOCKET_URL}/chat-room/${chatRoomId}/messages`,
+        `${process.env.NEXT_PUBLIC_CHAT_SOCKET_URL}/chat/${chatRoomId}/messages`,
       );
       const previousMessages = response.data;
       console.log('Previous messages:', previousMessages);
@@ -179,7 +179,7 @@ export const useGroupChat = (chatRoomId: string) => {
 
       try {
         stompClient.current?.publish({
-          destination: `/app/chat/${chatRoomId}/sendMessage`,
+          destination: `/app/chat/${chatRoomId}/send-messages`,
           body: JSON.stringify(messagePayload),
         });
         console.log('Message sent:', messagePayload);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,15 +13,7 @@ const middleware = (request: NextRequest) => {
 };
 
 export const config = {
-  matcher: [
-    '/api/study-posts/:path*/participants',
-    '/api/study-posts/:path*/applications',
-    '/api/study-posts/:path*/close',
-    '/api/comments',
-    '/api/study-posts/:path*/PUT',
-    '/api/qna-posts/:path*/PUT',
-    '/api/info-posts/:path*/PUT',
-  ],
+  matcher: ['/api/:path*'],
 };
 
 export default middleware;

--- a/src/mocks/handlers/signup.ts
+++ b/src/mocks/handlers/signup.ts
@@ -9,7 +9,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'INVALID_EMAIL',
-          message: '이메일을 입력해 주세요.',
+          errorMessage: '이메일을 입력해 주세요.',
         }),
       );
     }
@@ -19,7 +19,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'EMAIL_ALREADY_REGISTERED',
-          message: '이미 사용 중인 이메일입니다.',
+          errorMessage: '이미 사용 중인 이메일입니다.',
         }),
       );
     }
@@ -37,7 +37,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'INVALID_EMAIL',
-          message: '이메일을 입력해주세요.',
+          errorMessage: '이메일을 입력해주세요.',
         }),
       );
     }
@@ -61,7 +61,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'INVALID_CODE',
-          message: '인증 코드를 입력해주세요.',
+          errorMessage: '인증 코드를 입력해주세요.',
         }),
       );
     }
@@ -70,7 +70,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'VALIDATION_FAILED',
-          message: '인증 코드가 일치하지 않습니다.',
+          errorMessage: '인증 코드가 일치하지 않습니다.',
         }),
       );
     }
@@ -91,7 +91,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'INVALID_NICKNAME',
-          message: '닉네임을 입력해주세요.',
+          errorMessage: '닉네임을 입력해주세요.',
         }),
       );
     }
@@ -101,7 +101,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'NICKNAME_ALREADY_REGISTERED',
-          message: '이미 사용 중인 닉네임입니다.',
+          errorMessage: '이미 사용 중인 닉네임입니다.',
         }),
       );
     }
@@ -121,7 +121,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'INVALID_EMAIL',
-          message: '이메일을 입력하세요.',
+          errorMessage: '이메일을 입력하세요.',
         }),
       );
     }
@@ -146,7 +146,7 @@ export const signUpHandlers = [
         ctx.status(400),
         ctx.json({
           errorCode: 'INVALID_NICKNAME',
-          message: '닉네임을 입력하세요.',
+          errorMessage: '닉네임을 입력하세요.',
         }),
       );
     }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -31,7 +31,7 @@ export interface StudyPost {
   endTime: string;
   meetingType: string;
   recruitmentPeriod: string;
-  description: string;
+  content: string;
   latitude?: number;
   longitude?: number;
   address?: string;

--- a/src/utils/authHelper.ts
+++ b/src/utils/authHelper.ts
@@ -39,7 +39,7 @@ export const handleUserInfo = async (
       throw new Error('사용자 정보 조회에 실패했습니다.');
     }
 
-    const userInfo = userResponse.data;
+    const { isActive, createdAt, updatedAt, ...userInfo } = userResponse.data;
 
     // 3. 쿠키 설정
     const currentTime = Math.trunc(Date.now() / 1000);

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -33,5 +33,8 @@ export const deleteCookie = (res: NextResponse, name: string) => {
     path: '/', // 쿠키의 유효 경로
     sameSite: 'strict',
     maxAge: 0,
+    // expires: new Date(0),
   });
+
+  console.log(`쿠키 삭제됨: ${name}`);
 };


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 미들웨어
    - 미들웨어 config 파일에 여러 경로 포함되어 있음
    - 요청 url Rewrite 과정에서 쿼리 파라미터 데이터가 사라짐
    - 액세스토큰 재발급 함수 제대로 동작하지 않음
- 쿠키
    - 로그아웃 시 cookies.ts 파일의 deleteCookie 함수 사용하여 쿠키 삭제
- 네이버 소셜 로그인
    - 네이버 소셜 로그인 구현되어 있지 않음
- 마이페이지
    - 4개의 탭 디자인만 구현
- 회원 탈퇴
   - 회원 탈퇴 구현되어 있지 않음
- 회원가입
  - 이메일 확인 요청 응답에 성공해야 인증번호 전송 요청 가능
  - 비밀번호 특수문자 형식에 #, ^ 체크 하지 않음

**TO-BE**
- 미들웨어
    -  [/api/:path*']만 남기고 삭제
    - 요청 url Rewrite 과정에서 쿼리 파라미터 사라지지 않도록 수정
    - 액세스토큰 재발급 함수 동작하도록 수정 (새로고침 하지 않고 바로 동작하도록 수정 예정)
- 쿠키
    - 로그아웃 시 cookies.ts 파일의 deleteCookie 함수 사용하여 쿠키 삭제하지 않고, 직접 삭제하도록 수정(deleteCookie 함수 관련 문제 해결중)
- 네이버 소셜 로그인
    - 네이버 소셜 로그인 구현
- 회원 탈퇴
   - 회원 탈퇴 구현
- 마이페이지 목록 불러오기
    - 4개의 탭 속 카드 디자인 컴포넌트로 분리
    - 4개 탭 모두 백엔드 연동 완료
- 회원가입
  - 인증번호 전송 요청 api 에서 사용 가능한 이메일인지까지 체크
  - 비밀번호 특수문자 형식에 #, ^ 추가
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] 백엔드 연동 시 마이페이지 탭 4개 불러오기 테스트
- [X] 백엔드 연동 시 네이버 소셜 로그인 테스트
- [X] 백엔드 연동 시 액세스토큰 재발급 테스트