### PR TITLE
fix: 채팅 백엔드 연동 실패, 메시지 전송 에러, 실시간으로 메시지 렌더링 해결

### DIFF
--- a/src/app/api/chat/[chatRoomId]/messages/route.ts
+++ b/src/app/api/chat/[chatRoomId]/messages/route.ts
@@ -8,7 +8,6 @@ export const GET = async (
   const { chatRoomId } = await params;
   const searchParams = request.nextUrl.searchParams;
   const page = searchParams.get('page');
-  const size = searchParams.get('size');
 
   try {
     const response = await axios.get(
@@ -16,7 +15,6 @@ export const GET = async (
       {
         params: {
           page,
-          size,
         },
         headers: {
           'Content-Type': 'application/json',

--- a/src/app/chat/components/MessageInput.tsx
+++ b/src/app/chat/components/MessageInput.tsx
@@ -8,6 +8,7 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const messageInputRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -22,6 +23,10 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
       console.error('Failed to send message:', error);
     } finally {
       setIsLoading(false);
+
+      if (messageInputRef.current) {
+        messageInputRef.current.focus();
+      }
     }
   };
 
@@ -47,11 +52,13 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
         </button>
         <input
           type="text"
+          ref={messageInputRef}
           value={content}
           onChange={e => setContent(e.target.value)}
           placeholder="메시지를 입력하세요..."
           className="flex-1 input input-bordered bg-white"
           disabled={isLoading}
+          autoFocus
         />
         <button type="submit" className="btn btn-primary" disabled={isLoading}>
           {isLoading ? '전송 중...' : '전송'}

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
 import { useAuthStore } from '@/store/authStore';
+import axios from 'axios';
 
 interface MyStudyCardProps {
   post: MyStudyCardData;
@@ -91,31 +92,33 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
             className="btn btn-primary btn-sm"
             onClick={async e => {
               e.stopPropagation();
-              router.push(
-                `/chat/${1}/study/${1}?studyName=${encodeURIComponent('코테 스터디')}`,
-              );
-              // try {
-              //   const response = await axios.post(
-              //     `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/chat/study/${post.id}/participant/${userInfo?.id}`,
-              //     {},
-              //     {
-              //       headers: { 'Content-Type': 'application/json' },
-              //     },
-              //   );
-              //   if (response.status === 200) {
-              //     const { chatRoomId, studyId, studyName } = response.data;
-
-              //   } else {
-              //     alert(
-              //       '채팅방에 참여할 수 없습니다. 잠시 후 다시 시도해주세요.',
-              //     );
-              //   }
-              // } catch (error) {
-              //   console.error('채팅방 참가 중 오류 발생:', error);
-              //   alert(
-              //     '채팅방 참가 중 오류가 발생했습니다. 관리자에게 문의하세요.',
-              //   );
-              // }
+              // router.push(
+              //   `/chat/${1}/study/${1}?studyName=${encodeURIComponent('코테 스터디')}`,
+              // );
+              try {
+                const response = await axios.post(
+                  `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/chat/study/${post.id}/participant/${userInfo?.id}`,
+                  {},
+                  {
+                    headers: { 'Content-Type': 'application/json' },
+                  },
+                );
+                if (response.status === 200) {
+                  const { chatRoomId, studyId, studyName } = response.data;
+                  router.push(
+                    `/chat/${chatRoomId}/study/${studyId}?studyName=${studyName}`,
+                  );
+                } else {
+                  alert(
+                    '채팅방에 참여할 수 없습니다. 잠시 후 다시 시도해주세요.',
+                  );
+                }
+              } catch (error) {
+                console.error('채팅방 참가 중 오류 발생:', error);
+                alert(
+                  '채팅방 참가 중 오류가 발생했습니다. 관리자에게 문의하세요.',
+                );
+              }
             }}
           >
             채팅

--- a/src/app/signup/components/SignUpForm.tsx
+++ b/src/app/signup/components/SignUpForm.tsx
@@ -37,7 +37,7 @@ const SignUpForm = () => {
   >('');
 
   const [timer, setTimer] = useState(180);
-  const [isTimerRunning, setIsTimerRunning] = useState(false);
+  const [, setIsTimerRunning] = useState(false);
 
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [passwordCheckVisible, setPasswordCheckVisible] = useState(false);

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,11 +1,11 @@
 // 공통으로 사용되는 User 인터페이스
 export interface User {
   id: number;
-  email: string;
-  profileImageUrl: string | null;
-  isActive: boolean;
-  createdAt: string;
-  updatedAt: string;
+  email?: string;
+  profileImageUrl?: string | null;
+  isActive?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
   nickname: string;
 }
 

--- a/src/utils/authHelper.ts
+++ b/src/utils/authHelper.ts
@@ -39,7 +39,8 @@ export const handleUserInfo = async (
       throw new Error('사용자 정보 조회에 실패했습니다.');
     }
 
-    const { isActive, createdAt, updatedAt, ...userInfo } = userResponse.data;
+    const { id, nickname, email, profileImageUrl } = userResponse.data;
+    const userInfo = { id, nickname, email, profileImageUrl };
 
     // 3. 쿠키 설정
     const currentTime = Math.trunc(Date.now() / 1000);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 채팅
    - 이전 메시지 로드가 무한으로 요청됨
    - 웹소켓 연결 테스트 실패
    - 메시지를 전송해도 웹소켓 서버가 전달받지 못함
    - 실시간으로 주고받는 메시지가 화면에 렌더링되지 않음
    - 채팅방 첫 입장 시 웹소켓 연결 에러

**TO-BE**
- 채팅
    - 이전 메시지 로드가 한번만 실행
    - 웹소켓 연결 성공
    - 실시간으로 주고받는 메시지 화면에 렌더링됨
    - 채팅방 첫 입장 시 바로 웹소켓 연결 성공
    - 무한 스크롤 적용되지 않는 문제 해결중
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] 채팅 백엔드 연동 성공
- [X] 실시간 메시지 렌더링