### PR TITLE
refactor: 마이페이지 목록 불러오기 컴포넌트 리팩토링, 빌드 warning, error 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  images: {
+    domains: ['swany-bucket.s3.ap-northeast-2.amazonaws.com'], // 외부 이미지 도메인 추가
+  },
   async headers() {
     return [
       {

--- a/src/app/chat/[chatRoomId]/study/[studyId]/page.tsx
+++ b/src/app/chat/[chatRoomId]/study/[studyId]/page.tsx
@@ -1,10 +1,13 @@
 import ChatRoom from '@/app/chat/components/ChatRoom';
 
-const ChatPage = async ({
-  params,
-}: {
-  params: { chatRoomId: string; studyId: string };
-}) => {
+type ChatPageProps = {
+  params: Promise<{
+    chatRoomId: string;
+    studyId: string;
+  }>;
+};
+
+const ChatPage = async ({ params }: ChatPageProps) => {
   const { chatRoomId, studyId } = await params;
 
   return (

--- a/src/app/community/info/[id]/page.tsx
+++ b/src/app/community/info/[id]/page.tsx
@@ -1,9 +1,14 @@
 import InfoDetailContent from '@/app/community/components/InfoDetailContent';
 
-export default async function InfoDetailPage({
-  params,
-}: {
-  params: { id: string };
-}) {
-  return <InfoDetailContent postId={params.id} />;
-}
+type InfoDetailPageProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+const InfoDetailPage = async ({ params }: InfoDetailPageProps) => {
+  const { id } = await params;
+  return <InfoDetailContent postId={id} />;
+};
+
+export default InfoDetailPage;

--- a/src/app/community/qna/[id]/page.tsx
+++ b/src/app/community/qna/[id]/page.tsx
@@ -1,9 +1,14 @@
 import QnADetailContent from '@/app/community/components/QnADetailContent';
 
-export default async function QnADetailPage({
-  params,
-}: {
-  params: { id: string };
-}) {
-  return <QnADetailContent postId={params.id} />;
-}
+type QnADetailPageProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+const QnADetailPage = async ({ params }: QnADetailPageProps) => {
+  const { id } = await params;
+  return <QnADetailContent postId={id} />;
+};
+
+export default QnADetailPage;

--- a/src/app/community/study/[id]/page.tsx
+++ b/src/app/community/study/[id]/page.tsx
@@ -1,10 +1,12 @@
 import StudyDetailContent from './components/StudyDetailContent';
 
-export default async function StudyDetailPage({
-  params,
-}: {
-  params: { id: string };
-}) {
+type StudyDetailPageProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+const StudyDetailPage = async ({ params }: StudyDetailPageProps) => {
   const { id } = await params;
   return (
     <div>
@@ -12,4 +14,6 @@ export default async function StudyDetailPage({
       <StudyDetailContent studyId={id} />
     </div>
   );
-}
+};
+
+export default StudyDetailPage;

--- a/src/app/community/study/components/StudyCard.tsx
+++ b/src/app/community/study/components/StudyCard.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
 import { StudyPost } from '@/types/post';
+import Image from 'next/image';
 
 interface StudyCardProps {
   post: StudyPost;
@@ -17,9 +18,11 @@ export function StudyCard({ post }: StudyCardProps) {
       onClick={() => router.push(`/community/study/${post.id}`)}
     >
       <figure className="px-4 pt-4">
-        <img
+        <Image
           src={post.thumbnailImgUrl || '/default-study-thumbnail.png'}
           alt={post.title}
+          width={500}
+          height={300}
           className="rounded-xl h-48 w-full object-cover"
         />
       </figure>

--- a/src/app/mypage/components/MyInfoPostCard.tsx
+++ b/src/app/mypage/components/MyInfoPostCard.tsx
@@ -3,6 +3,7 @@
 import { InfoPost } from '@/types/post';
 import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
+import Image from 'next/image';
 
 interface MyPostCardProps {
   post: InfoPost;
@@ -21,9 +22,11 @@ const MyInfoPostCard = ({ post }: MyPostCardProps) => {
       onClick={() => router.push(`/community/info/${post.id}`)}
     >
       <figure className="px-4 pt-4">
-        <img
+        <Image
           src={post?.thumbnailImgUrl || '/default-study-thumbnail.png'}
           alt={post.title}
+          width={500}
+          height={300}
           className="rounded-xl h-48 w-full object-cover"
         />
       </figure>

--- a/src/app/mypage/components/MyQnAPostCard.tsx
+++ b/src/app/mypage/components/MyQnAPostCard.tsx
@@ -3,6 +3,7 @@
 import { QnAPost } from '@/types/post';
 import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
+import Image from 'next/image';
 
 interface MyPostCardProps {
   post: QnAPost;
@@ -21,9 +22,11 @@ const MyQnAPostCard = ({ post }: MyPostCardProps) => {
       onClick={() => router.push(`/community/qna/${post.id}`)}
     >
       <figure className="px-4 pt-4">
-        <img
+        <Image
           src={post?.thumbnailImgUrl || '/default-study-thumbnail.png'}
           alt={post.title}
+          width={500}
+          height={300}
           className="rounded-xl h-48 w-full object-cover"
         />
       </figure>

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
 import { useAuthStore } from '@/store/authStore';
 import axios from 'axios';
+import Image from 'next/image';
 
 interface MyStudyCardProps {
   post: MyStudyCardData;
@@ -41,9 +42,11 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
       onClick={() => router.push(`/community/study/${post.studyPostId}`)}
     >
       <figure className="px-4 pt-4">
-        <img
+        <Image
           src={post.thumbnailImgUrl || '/default-study-thumbnail.png'}
           alt={post.studyName}
+          width={500}
+          height={300}
           className="rounded-xl h-48 w-full object-cover"
         />
       </figure>

--- a/src/app/mypage/components/MyStudyView.tsx
+++ b/src/app/mypage/components/MyStudyView.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { StudyPost, InfoPost, QnAPost } from '@/types/post';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import axios from 'axios';
 import { useAuthStore } from '@/store/authStore';
 import MyStudyCard from './MyStudyCard';
@@ -28,402 +28,155 @@ const MyStudyView = () => {
 
   const router = useRouter();
 
-  // useEffect(() => {
-  //   if (isSignedIn === false) {
-  //     resetStore();
-  //     router.push('/signin');
-  //   }
-  // }, [isSignedIn]);
+  const tabConfigs = {
+    myStudy: {
+      url: `/study/author/${userInfo?.id}`,
+      setData: setMyStudies,
+      logMessage: '나의 스터디 불러오기 성공',
+    },
+    myStudyPost: {
+      url: `/study-posts/author/${userInfo?.id}`,
+      setData: setMyStudyPosts,
+      logMessage: '나의 스터디 모집글 불러오기 성공',
+    },
+    myInfoPost: {
+      url: `/info-posts/author/${userInfo?.id}`,
+      setData: setMyInfoPosts,
+      logMessage: '나의 정보 공유 게시글 불러오기 성공',
+    },
+    myQnAPost: {
+      url: `/qna-posts/author/${userInfo?.id}`,
+      setData: setMyQnAPosts,
+      logMessage: '나의 Q&A 게시글 불러오기 성공',
+    },
+  };
+
+  const handleTabClick = useCallback(
+    async (tab: keyof typeof tabConfigs, page = 0) => {
+      setActiveTab(tab);
+      setError(null);
+      const config = tabConfigs[tab];
+
+      if (userInfo?.id) {
+        try {
+          if (userInfo?.id) {
+            const response = await axios.get(
+              `${process.env.NEXT_PUBLIC_API_ROUTE_URL}${config.url}?page=${page}`,
+            );
+
+            if (response.status === 200 && response.data) {
+              config.setData(response.data.content);
+
+              setPagination({
+                currentPage: response.data.pageable.pageNumber + 1,
+                pageSize: response.data.pageable.pageSize,
+                totalElements: response.data.totalElements,
+              });
+              console.log(config.logMessage);
+            }
+          }
+        } catch (error: any) {
+          handleApiError(error);
+        }
+      }
+    },
+    [userInfo?.id],
+  );
+
+  const handleApiError = (error: any) => {
+    console.log('에러 상태코드', error.response.status);
+    if (error.response) {
+      const { status, data } = error.response;
+      console.log('error:' + error.response);
+      const message =
+        data?.errorMessage || '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+      if (status === 401) {
+        console.log('토큰 문제 발생. 로그인이 필요합니다.');
+        router.push('/signin');
+        resetStore();
+      } else {
+        setError(message);
+      }
+    } else {
+      setError('게시글 목록을 불러오는 데 실패했습니다.');
+    }
+  };
 
   useEffect(() => {
-    // 마이페이지가 처음 로드될 때 'myStudy' 탭 클릭 상태
     if (isSignedIn && userInfo?.id) {
       handleTabClick('myStudy');
     }
-  }, [isSignedIn, userInfo]);
-
-  // const handleTabClick = async (tab: string, page = 0) => {
-  //   setActiveTab(tab);
-  //   setError(null);
-  //   try {
-  //     let url = '';
-  //     if (tab === 'myStudy') {
-  //       url = `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/study/author/${userInfo?.id}?page=${page}`;
-  //     } else if (tab === 'myStudyPost') {
-  //       url = `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/study-posts/author/${userInfo?.id}?page=${page}`;
-  //     } else if (tab === 'myInfoPost') {
-  //       url = `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/info-posts/author/${userInfo?.id}?page=${page}`;
-  //     } else if (tab === 'myQnAPost') {
-  //       url = `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/qna-posts/author/${userInfo?.id}?page=${page}`;
-  //     }
-
-  //     const response = await axios.get(url, {
-  //       headers: { 'Content-Type': 'application/json' },
-  //     });
-  //     if (response.status === 200 && response.data) {
-  //       const data = response.data;
-
-  //       // Update the state based on the active tab
-  //       if (tab === 'myStudy') {
-  //         setMyStudies(data.content);
-  //       } else if (tab === 'myStudyPost') {
-  //         setMyStudyPosts(data.content);
-  //       } else if (tab === 'myInfoPost') {
-  //         setMyInfoPosts(data.content);
-  //       } else if (tab === 'myQnAPost') {
-  //         setMyQnAPosts(data.content);
-  //       }
-
-  //       // Update pagination state
-  //       setPagination({
-  //         currentPage: data.pageable.pageNumber,
-  //         totalPages: data.totalPages,
-  //       });
-  //     }
-  //   } catch (error: any) {
-  //     const message =
-  //       error.response?.data?.errorMessage ||
-  //       '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
-  //     setError(message);
-  //   }
-  // };
-
-  // const handlePageChange = (newPage: number) => {
-  //   handleTabClick(activeTab, newPage);
-  // };
-
-  // 탭 클릭 핸들러
-  const handleTabClick = (tab: string, page = 0) => {
-    setActiveTab(tab);
-    setError(null);
-    if (tab === 'myStudy') {
-      handleMyStudyTabClick(page);
-    } else if (tab === 'myStudyPost') {
-      handleMyStudyPostTabClick(page);
-    } else if (tab === 'myInfoPost') {
-      handleMyInfoPostTabClick(page);
-    } else if (tab === 'myQnAPost') {
-      handleMyQnAPostTabClick(page);
-    }
-  };
+  }, [isSignedIn, userInfo, handleTabClick]);
 
   const handlePageChange = (newPage: number) => {
-    handleTabClick(activeTab, newPage);
+    handleTabClick(activeTab as keyof typeof tabConfigs, newPage);
   };
 
-  const handleMyStudyTabClick = async (page: number) => {
-    try {
-      if (userInfo?.id) {
-        const response = await axios.get(
-          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/study/author/${userInfo?.id}?page=${page}`,
-        );
-
-        if (response.status === 200 && response.data) {
-          setMyStudies(response.data.content);
-
-          setPagination({
-            currentPage: response.data.pageable.pageNumber + 1,
-            pageSize: response.data.pageable.pageSize,
-            totalElements: response.data.totalElements,
-          });
-        }
-      }
-    } catch (error: any) {
-      console.log('에러 상태코드', error.response.status);
-      if (error.response) {
-        const { status, data } = error.response;
-        console.log('error:' + error.response);
-        const message =
-          data?.errorMessage ||
-          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
-        setError(message);
-        if (status === 401) {
-          console.log('토큰 문제 발생. 로그인이 필요합니다.');
-          router.push('/signin');
-          resetStore();
-        } else {
-          setError(message);
-        }
-      } else {
-        setError('내가 속한 스터디 목록을 불러오는 데 실패했습니다.');
-      }
-    }
-  };
-
-  const handleMyStudyPostTabClick = async (page: number) => {
-    try {
-      if (userInfo?.id) {
-        const response = await axios.get(
-          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/study-posts/author/${userInfo?.id}?page=${page}`,
-          {
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
-        if (response.status === 200 && response.data) {
-          setMyStudyPosts(response.data.content);
-
-          setPagination({
-            currentPage: response.data.pageable.pageNumber + 1,
-            pageSize: response.data.pageable.pageSize,
-            totalElements: response.data.totalElements,
-          });
-          console.log('나의 스터디 모집 글 불러오기 성공했습니다.');
-        }
-      }
-    } catch (error: any) {
-      if (error.response) {
-        const { status, data } = error.response;
-        console.log('error:' + error.response);
-        const message =
-          data?.errorMessage ||
-          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
-        if (status === 401) {
-          console.log('토큰 문제 발생. 로그인이 필요합니다.');
-          router.push('/signin');
-          resetStore();
-        } else {
-          setError(message);
-        }
-      } else {
-        setError('나의 스터디 모집 글 목록을 불러오는 데 실패했습니다.');
-      }
-    }
-  };
-
-  const handleMyInfoPostTabClick = async (page: number) => {
-    try {
-      if (userInfo?.id) {
-        const response = await axios.get(
-          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/info-posts/author/${userInfo?.id}?page=${page}`,
-          {
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
-        if (response.status === 200 && response.data) {
-          setMyInfoPosts(response.data.content);
-
-          setPagination({
-            currentPage: response.data.pageable.pageNumber + 1,
-            pageSize: response.data.pageable.pageSize,
-            totalElements: response.data.totalElements,
-          });
-          console.log('나의 정보 공유 게시글 불러오기 성공했습니다.');
-        }
-      }
-    } catch (error: any) {
-      if (error.response) {
-        const { status, data } = error.response;
-        console.log('error:' + error.response.data.errorMessage);
-        const message =
-          data?.errorMessage ||
-          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
-        if (status === 401) {
-          console.log('토큰 문제 발생. 로그인이 필요합니다.');
-          router.push('/signin');
-          resetStore();
-        } else {
-          setError(message);
-        }
-      } else {
-        setError('나의 정보 공유 게시글 목록을 불러오는 데 실패했습니다.');
-      }
-    }
-  };
-
-  const handleMyQnAPostTabClick = async (page: number) => {
-    try {
-      if (userInfo?.id) {
-        const response = await axios.get(
-          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/qna-posts/author/${userInfo?.id}?page=${page}`,
-          {
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
-        if (response.status === 200 && response.data) {
-          setMyQnAPosts(response.data.content);
-
-          setPagination({
-            currentPage: response.data.pageable.pageNumber + 1,
-            pageSize: response.data.pageable.pageSize,
-            totalElements: response.data.totalElements,
-          });
-          console.log('나의 Q&A 게시글 불러오기 성공했습니다.');
-        }
-      }
-    } catch (error: any) {
-      if (error.response) {
-        const { status, data } = error.response;
-        console.log('error:' + error.response);
-        const message =
-          data?.errorMessage ||
-          '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
-        if (status === 401) {
-          console.log('토큰 문제 발생. 로그인이 필요합니다.');
-          router.push('/signin');
-          resetStore();
-        } else {
-          setError(message);
-        }
-      } else {
-        setError('나의 Q&A 게시글 목록을 불러오는 데 실패했습니다.');
-      }
-    }
-  };
-
-  // 탭 클릭 시 해당 탭의 내용을 보여주는 함수
   const renderTabContent = () => {
-    if (!isSignedIn) {
-      return (
-        <p className="col-span-full text-center text-gray-500">
-          로그인이 필요합니다.
-        </p>
-      );
-    }
-    if (error) {
-      return <p className="col-span-full text-center text-red-500">{error}</p>;
-    }
+    const contentMap = {
+      myStudy: {
+        data: myStudies,
+        component: MyStudyCard,
+        emptyMessage: '내가 속한 스터디가 없습니다.',
+      },
+      myStudyPost: {
+        data: myStudyPosts,
+        component: StudyCard,
+        emptyMessage: '작성한 스터디 모집 글이 없습니다.',
+      },
+      myInfoPost: {
+        data: myInfoPosts,
+        component: MyInfoPostCard,
+        emptyMessage: '작성한 정보 공유 게시글이 없습니다.',
+      },
+      myQnAPost: {
+        data: myQnAPosts,
+        component: MyQnAPostCard,
+        emptyMessage: '작성한 Q&A 게시글이 없습니다.',
+      },
+    };
 
-    switch (activeTab) {
-      case 'myStudy':
-        return (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {!isSignedIn ? (
-              <p className="col-span-full text-center text-gray-500">
-                로그인이 필요합니다.
-              </p>
-            ) : !myStudies ? (
-              <p className="col-span-full text-center text-gray-500">
-                내가 속한 스터디를 불러오는 중입니다...
-              </p>
-            ) : myStudies.length === 0 ? (
-              <p className="col-span-full text-center text-gray-500">
-                내가 속한 스터디가 없습니다.
-              </p>
-            ) : (
-              myStudies.map(myStudy => (
-                <MyStudyCard key={myStudy.studyPostId} post={myStudy} />
-              ))
-            )}
-          </div>
-        );
-      case 'myStudyPost':
-        return (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {!isSignedIn ? (
-              <p className="col-span-full text-center text-gray-500">
-                로그인이 필요합니다.
-              </p>
-            ) : !myStudyPosts ? (
-              <p className="col-span-full text-center text-gray-500">
-                작성한 스터디 모집 글을 불러오는 중입니다...
-              </p>
-            ) : myStudyPosts.length === 0 ? (
-              <p className="col-span-full text-center text-gray-500">
-                작성한 스터디 모집 글이 없습니다.
-              </p>
-            ) : (
-              myStudyPosts.map(myStudyPost => (
-                <StudyCard key={myStudyPost.id} post={myStudyPost} />
-              ))
-            )}
-          </div>
-        );
-      case 'myInfoPost':
-        return (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {!isSignedIn ? (
-              <p className="col-span-full text-center text-gray-500">
-                로그인이 필요합니다.
-              </p>
-            ) : !myInfoPosts ? (
-              <p className="col-span-full text-center text-gray-500">
-                작성한 정보 공유 게시글을 불러오는 중입니다...
-              </p>
-            ) : myInfoPosts.length === 0 ? (
-              <p className="col-span-full text-center text-gray-500">
-                작성한 정보 공유 게시글이 없습니다.
-              </p>
-            ) : (
-              myInfoPosts.map(myInfoPost => (
-                <MyInfoPostCard key={myInfoPost.id} post={myInfoPost} />
-              ))
-            )}
-          </div>
-        );
+    const currentTab = contentMap[activeTab as keyof typeof contentMap];
+    if (!isSignedIn) return <p>로그인이 필요합니다.</p>;
+    if (error) return <p className="text-red-500">{error}</p>;
+    if (!currentTab.data || currentTab.data.length === 0)
+      return <p>{currentTab.emptyMessage}</p>;
 
-      case 'myQnAPost':
-        return (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {!isSignedIn ? (
-              <p className="col-span-full text-center text-gray-500">
-                로그인이 필요합니다.
-              </p>
-            ) : !myQnAPosts ? (
-              <p className="col-span-full text-center text-gray-500">
-                작성한 Q&A 게시글을 불러오는 중입니다...
-              </p>
-            ) : myQnAPosts.length === 0 ? (
-              <p className="col-span-full text-center text-gray-500">
-                작성한 Q&A 게시글이 없습니다.
-              </p>
-            ) : (
-              myQnAPosts.map(myQnAPost => (
-                <MyQnAPostCard key={myQnAPost.id} post={myQnAPost} />
-              ))
-            )}
-          </div>
-        );
-      default:
-        return <p>기타 탭에 대한 내용</p>;
-    }
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {currentTab.data.map((post: any) => (
+          <currentTab.component key={post.id} post={post} />
+        ))}
+      </div>
+    );
   };
 
   return (
     <div className="p-6 space-y-6">
       <div role="tablist" className="tabs tabs-lifted">
-        <button
-          onClick={() => handleTabClick('myStudy')}
-          className={`tab tab-lg ${
-            activeTab === 'myStudy' ? 'tab-active shadow-lg font-bold' : ''
-          }`}
-        >
-          내가 속한 스터디
-        </button>
-        <button
-          onClick={() => handleTabClick('myStudyPost')}
-          className={`tab tab-lg ${
-            activeTab === 'myStudyPost' ? 'tab-active shadow-lg font-bold' : ''
-          }`}
-        >
-          나의 스터디 모집글
-        </button>
-        <button
-          onClick={() => handleTabClick('myInfoPost')}
-          className={`tab tab-lg ${
-            activeTab === 'myInfoPost' ? 'tab-active shadow-lg font-bold' : ''
-          }`}
-        >
-          나의 정보 공유
-        </button>
-        <button
-          onClick={() => handleTabClick('myQnAPost')}
-          className={`tab tab-lg ${
-            activeTab === 'myQnAPost' ? 'tab-active shadow-lg font-bold' : ''
-          }`}
-        >
-          나의 Q&A
-        </button>
+        {Object.keys(tabConfigs).map(tab => (
+          <button
+            key={tab}
+            onClick={() => handleTabClick(tab as keyof typeof tabConfigs)}
+            className={`tab tab-lg ${
+              activeTab === tab ? 'tab-active shadow-lg font-bold' : ''
+            }`}
+          >
+            {tab === 'myStudy' && '내가 속한 스터디'}
+            {tab === 'myStudyPost' && '나의 스터디 모집글'}
+            {tab === 'myInfoPost' && '나의 정보 공유'}
+            {tab === 'myQnAPost' && '나의 Q&A'}
+          </button>
+        ))}
       </div>
       <div className="p-4 bg-base-200 rounded-lg shadow-md border-t-4 border-primary">
-        <div>
-          {renderTabContent()}
-          <Pagination
-            totalElements={pagination.totalElements} // 전체 게시물 수
-            pageSize={pagination.pageSize} // 한 페이지에 표시할 게시물 수
-            currentPage={pagination.currentPage} // 현재 페이지
-            onPageChange={handlePageChange} // 페이지 변경 함수
-          />
-        </div>
+        {renderTabContent()}
+        <Pagination
+          totalElements={pagination.totalElements}
+          pageSize={pagination.pageSize}
+          currentPage={pagination.currentPage}
+          onPageChange={handlePageChange}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 빌드 warning, error 해결
    - `img` 태그 사용
    - 요청 url Rewrite 과정에서 쿼리 파라미터 데이터가 사라짐
- 마이페이지 리팩토링
    - 탭 4개에 해당하는 요청을 하나씩 구현
    - 각 탭별로 에러 처리가 중복됨

**TO-BE**
- 빌드 warning, error 해결
  - `next/image` 의 `<Image />` 컴포넌트 사용하여 성능 개선
  - Next.js의 App Router 방식에서는 params가 비동기적으로 제공될 수 있기 때문에, prams를 `Promise`로 래핑하여 비동기적으로 처리
- 마이페이지 리팩토링
    - `useCallback` 함수 활용하여 컴포넌트가 불필요하게 리렌더링되지 않도록 수정
    - `handleTabClick` 함수 하나로 모든 탭에 대한 요청을 처리
    - 에러 처리 함수 `handleApiError` 로 에러 처리 부분을 통합하여 중복을 줄임
    - `renderTabContent` 함수에서 탭의 데이터를 처리하고, 필요한 컴포넌트를 동적으로 렌더링
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] 마이페이지 탭 4개 불러오기 테스트
- [X] warning 에러 해결 후 동작 테스트