### PR TITLE
feat: 회원 탈퇴 확인 절차 구현 / fix: 회원가입 타이머 수정, 빌드 warning 해결 / WIP: 채팅 이전 메시지 로드 에러 해결중

### DIFF
--- a/src/app/api/auth/withdrawal/route.ts
+++ b/src/app/api/auth/withdrawal/route.ts
@@ -1,14 +1,17 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 import { cookies } from 'next/headers';
 
-export const POST = async () => {
+export const POST = async (req: NextRequest) => {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
+
+  const { password } = await req.json();
+
   try {
     await axios.post(
       `${process.env.API_URL}/auth/withdrawal`,
-      {},
+      { password },
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/app/api/chat/[chatRoomId]/messages/route.ts
+++ b/src/app/api/chat/[chatRoomId]/messages/route.ts
@@ -8,7 +8,7 @@ export const GET = async (
   // const { chatRoomId } = await params;
   const chatRoomId = request.nextUrl.pathname.split('/')[3] as string;
   const searchParams = request.nextUrl.searchParams;
-  const page = searchParams.get('page');
+  const page = searchParams.get('page') || '0';
 
   try {
     const response = await axios.get(

--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -70,18 +70,19 @@ const ChatRoom = ({ chatRoomId, studyId }: ChatRoomProps) => {
     const shouldLoadMore =
       inView && hasNextPage && !isFetchingNextPage && !loadError;
 
-    console.log('Load previous messages conditions:', {
+    console.log('이전 메시지 로드 조건', {
       inView,
       hasNextPage,
       isFetchingNextPage,
       loadError,
       shouldLoadMore,
+      currentMessageCount: messages.length,
     });
 
     if (shouldLoadMore) {
       handleFetchPreviousMessages();
     }
-  }, [inView, hasNextPage, isFetchingNextPage, loadError]);
+  }, [inView, hasNextPage, isFetchingNextPage, loadError, messages.length]);
 
   // // 스크롤 맨 아래로 이동
   // useEffect(() => {
@@ -180,7 +181,12 @@ const ChatRoom = ({ chatRoomId, studyId }: ChatRoomProps) => {
                       alt={`${msg.user.id}'s profile`}
                       className="w-8 h-8 rounded-full"
                     />
-                    <div className="text-xs text-gray-600">{msg.user.id}</div>
+                    <div
+                      className="text-xs text-gray-600 truncate max-w-[100px] nickname"
+                      title={msg.user.nickname}
+                    >
+                      {msg.user.nickname}
+                    </div>
                   </div>
                 )}
 
@@ -232,7 +238,12 @@ const ChatRoom = ({ chatRoomId, studyId }: ChatRoomProps) => {
                       alt="My profile"
                       className="w-8 h-8 rounded-full"
                     />
-                    <div className="text-xs text-gray-600">{msg.user.id}</div>
+                    <div
+                      className="text-xs text-gray-600 truncate max-w-[100px] nickname"
+                      title={msg.user.nickname}
+                    >
+                      {msg.user.nickname}
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,3 +8,10 @@
     @apply text-base-content;
   }
 }
+
+@media (max-width: 768px) {
+  .nickname {
+    max-width: 70px; /* 더 짧게 */
+    font-size: 0.75rem; /* 폰트 크기 감소 */
+  }
+}

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -5,6 +5,8 @@ import dayjs from 'dayjs';
 import { useAuthStore } from '@/store/authStore';
 import axios from 'axios';
 import Image from 'next/image';
+import CustomAlert from '@/components/common/Alert';
+import { useState } from 'react';
 
 interface MyStudyCardProps {
   post: MyStudyCardData;
@@ -30,6 +32,9 @@ export interface MyStudyCardData {
 const MyStudyCard = ({ post }: MyStudyCardProps) => {
   const router = useRouter();
   const { userInfo } = useAuthStore();
+
+  const [showAlert, setShowAlert] = useState(false);
+  const [alertMessage, setAlertMessage] = useState('');
 
   // 시간에서 :00을 제거하는 함수
   const formatTime = (time: string) => {
@@ -112,15 +117,17 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
                     `/chat/${chatRoomId}/study/${studyId}?studyName=${studyName}`,
                   );
                 } else {
-                  alert(
+                  setAlertMessage(
                     '채팅방에 참여할 수 없습니다. 잠시 후 다시 시도해주세요.',
                   );
+                  setShowAlert(true);
                 }
               } catch (error) {
                 console.error('채팅방 참가 중 오류 발생:', error);
-                alert(
+                setAlertMessage(
                   '채팅방 참가 중 오류가 발생했습니다. 관리자에게 문의하세요.',
                 );
+                setShowAlert(true);
               }
             }}
           >
@@ -139,6 +146,12 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
           </button>
         </div>
       </div>
+      {showAlert && (
+        <CustomAlert
+          message={alertMessage}
+          onClose={() => setShowAlert(false)}
+        />
+      )}
     </div>
   );
 };

--- a/src/app/mypage/components/UserInfoView.tsx
+++ b/src/app/mypage/components/UserInfoView.tsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 import CustomConfirm from '@/components/common/Confirm';
 import CustomAlert from '@/components/common/Alert';
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
 
 const UserInfoView = () => {
   const { userInfo, setUserInfo, resetStore } = useAuthStore();
@@ -13,6 +14,10 @@ const UserInfoView = () => {
     userInfo?.profileImageUrl || '/default-profile-image.png',
   );
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
+
+  const [password, setPassword] = useState('');
+  const [isPasswordRequired, setIsPasswordRequired] = useState(false);
+
   const [showConfirm, setShowConfirm] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
   const [confirmMessage, setConfirmMessage] = useState('');
@@ -176,9 +181,16 @@ const UserInfoView = () => {
 
   const handleWithdrawalButtonClick = () => {
     setConfirmMessage(
-      '회원 탈퇴를 진행하시겠습니까? 탈퇴 시 회원 정보 및 모든 데이터가 삭제되며 복구할 수 없습니다.',
+      '회원 탈퇴를 진행하시겠습니까? \n 탈퇴 시 회원 정보 및 모든 데이터가 삭제되며 복구할 수 없습니다.',
     );
+    setIsPasswordRequired(true);
     setOnConfirmCallback(() => async () => {
+      if (isPasswordRequired && !password) {
+        setAlertMessage('비밀번호를 입력해주세요.');
+        setShowAlert(true);
+        return;
+      }
+
       try {
         const response = await axios.post(
           `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/auth/withdrawal`,
@@ -193,6 +205,9 @@ const UserInfoView = () => {
           setAlertMessage(
             '회원 탈퇴가 완료되었습니다. 이용해 주셔서 감사합니다.',
           );
+          setShowAlert(true);
+        } else {
+          setAlertMessage('다시 시도해 주세요.');
           setShowAlert(true);
         }
       } catch (error: any) {
@@ -216,6 +231,8 @@ const UserInfoView = () => {
         setShowAlert(true);
       } finally {
         setShowConfirm(false);
+        setPassword('');
+        setIsPasswordRequired(false);
       }
     });
     setShowConfirm(true);
@@ -282,9 +299,11 @@ const UserInfoView = () => {
     <div className="flex flex-col md:flex-row gap-8 p-8 max-w-4xl mx-auto">
       <div className="flex flex-col items-center w-full md:w-1/3 border-r pr-4">
         <div className="relative">
-          <img
+          <Image
             src={profileImageUrl || '/default-avatar.png'}
             alt="Profile"
+            width={500}
+            height={300}
             className="w-32 h-32 rounded-full object-cover border"
           />
         </div>
@@ -372,9 +391,22 @@ const UserInfoView = () => {
         <CustomConfirm
           message={confirmMessage}
           onConfirm={onConfirmCallback}
-          onCancel={() => setShowConfirm(false)}
+          onCancel={() => {
+            setShowConfirm(false);
+            setPassword('');
+          }}
+          requirePasswordInput={isPasswordRequired} // 비밀번호 필드 활성화 여부
+          inputValue={password} // 비밀번호 state와 연결
+          onInputChange={setPassword} // 비밀번호 입력 핸들러
         />
       )}
+      {/* {showConfirm && (
+        <CustomConfirm
+          message={confirmMessage}
+          onConfirm={onConfirmCallback}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )} */}
       {showAlert && (
         <CustomAlert
           message={alertMessage}

--- a/src/app/signup/components/SignUpForm.tsx
+++ b/src/app/signup/components/SignUpForm.tsx
@@ -107,6 +107,7 @@ const SignUpForm = () => {
         setEmailSent(true);
         setEmailMessage('인증번호가 발송되었습니다.');
         setEmailMessageType('success');
+        setTimer(180);
       } else {
         setEmailMessage('인증번호 전송에 실패했습니다.');
         setEmailMessageType('error');
@@ -162,24 +163,30 @@ const SignUpForm = () => {
       }
     } catch (error: any) {
       if (error.response) {
-        const { status, data } = error.response;
-        const errorCode = data?.errorCode;
+        const { data } = error.response;
+        const message = data?.errorMessage;
 
-        if (status === 400) {
-          if (errorCode === 'EMAIL_VERIFICATION_FAILED') {
-            setAuthCodeMessage('인증 코드가 만료되었습니다.');
-            setAuthCodeMessageType('error');
-          } else if (errorCode === 'VALIDATION_FAILED') {
-            setAuthCodeMessage('인증 코드가 일치하지 않습니다.');
-            setAuthCodeMessageType('error');
-          } else {
-            setAuthCodeMessage('잘못된 요청입니다. 다시 시도해주세요.');
-            setAuthCodeMessageType('error');
-          }
-        } else {
-          setAuthCodeMessage('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-          setAuthCodeMessageType('error');
-        }
+        // const { status, data } = error.response;
+        // const errorCode = data?.errorCode;
+        // const message = data?.errorMessage
+
+        // if (status === 400) {
+        //   if (errorCode === 'EMAIL_VERIFICATION_FAILED') {
+        //     setAuthCodeMessage('인증 코드가 만료되었습니다.');
+        //     setAuthCodeMessageType('error');
+        //   } else if (errorCode === 'VALIDATION_FAILED') {
+        //     setAuthCodeMessage('인증 코드가 일치하지 않습니다.');
+        //     setAuthCodeMessageType('error');
+        //   } else {
+        //     setAuthCodeMessage('잘못된 요청입니다. 다시 시도해주세요.');
+        //     setAuthCodeMessageType('error');
+        //   }
+        // } else {
+        //   setAuthCodeMessage('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+        //   setAuthCodeMessageType('error');
+        // }
+        setAuthCodeMessage(message);
+        setAuthCodeMessageType('error');
       } else {
         setAuthCodeMessage(
           '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',

--- a/src/components/common/Confirm/index.tsx
+++ b/src/components/common/Confirm/index.tsx
@@ -1,17 +1,24 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { FaRegEye, FaRegEyeSlash } from 'react-icons/fa';
 
 type CustomConfirmProps = {
   message: string;
   onConfirm: () => void;
   onCancel: () => void;
+  requirePasswordInput?: boolean;
+  inputValue?: string;
+  onInputChange?: (value: string) => void;
 };
 
 const CustomConfirm = ({
   message,
   onConfirm,
   onCancel,
+  requirePasswordInput = false,
+  inputValue = '',
+  onInputChange = () => {},
 }: CustomConfirmProps) => {
   useEffect(() => {
     const handleOutsideClick = (e: MouseEvent) => {
@@ -23,13 +30,42 @@ const CustomConfirm = ({
     return () => document.removeEventListener('click', handleOutsideClick);
   }, [onCancel]);
 
+  const [passwordVisible, setPasswordVisible] = useState(false);
+  const togglePasswordVisibility = () => {
+    setPasswordVisible(!passwordVisible);
+  };
+
   return (
     <div
       id="custom-confirm"
       className="fixed inset-0 flex items-center justify-center bg-gray-500 bg-opacity-50 z-50"
     >
       <div className="bg-white p-6 rounded-lg shadow-lg w-96 max-w-lg">
-        <p className="text-lg font-semibold text-center">{message}</p>
+        <p className="text-lg font-semibold text-center whitespace-pre-wrap break-words mb-4">
+          {message}
+        </p>
+        {requirePasswordInput && (
+          <div className="relative">
+            <input
+              type={passwordVisible ? 'text' : 'password'}
+              value={inputValue}
+              onChange={e => onInputChange(e.target.value)}
+              placeholder="비밀번호를 입력해주세요"
+              className="w-full input input-bordered px-4 py-2 focus:outline-indigo-500 text-sm sm:text-base"
+            />
+            <button
+              type="button"
+              onClick={togglePasswordVisibility}
+              className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+            >
+              {passwordVisible ? (
+                <FaRegEye size={20} />
+              ) : (
+                <FaRegEyeSlash size={20} />
+              )}
+            </button>
+          </div>
+        )}
         <div className="mt-6 flex justify-center space-x-4">
           <button className="btn btn-ghost" onClick={onCancel}>
             아니오

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -61,7 +61,7 @@ const Header = () => {
     console.log('로그인 상태는', storedSignedIn);
     setIsSignedIn(storedSignedIn);
     setIsLoading(false); // 로딩 완료
-  }, []);
+  }, [setIsSignedIn]);
 
   useEffect(() => {
     console.log(`닉네임: ${userInfo?.nickname}`);

--- a/src/hooks/useGroupChat.ts
+++ b/src/hooks/useGroupChat.ts
@@ -87,7 +87,15 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
     }) => fetchChatMessages({ pageParam, chatRoomId, signal }),
     getNextPageParam: (lastPage: any) =>
       lastPage.hasNextPage ? lastPage.page + 1 : undefined, // hasNextPage가 true일 때만 페이지 추가
+    // getNextPageParam: (lastPage: any, allPages: any[]) => {
+    // 현재 로드된 페이지 수를 기준으로 다음 페이지 결정
+    // if (allPages.length === 1) return 1;
+    // return lastPage.hasNextPage ? allPages.length : undefined;
+    // },
     initialPageParam: 0,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 60,
+    maxPages: 1,
   });
 
   console.log('isFetchingNextPage: ', isFetchingNextPage);
@@ -121,10 +129,17 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
 
   const isConnecting = useRef(false);
 
+  // const messagesWithoutDuplicates = useMemo(() => {
+  //   // 중복 제거 및 정렬 로직
+  //   return Array.from(new Map(messages.map(m => [m.id, m])).values()).sort(
+  //     (a, b) =>
+  //       new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  //   );
+  // }, [messages]);
   const messagesWithoutDuplicates = useMemo(() => {
-    // 중복 제거 및 정렬 로직
     return Array.from(new Map(messages.map(m => [m.id, m])).values()).sort(
       (a, b) =>
+        // 오래된 메시지가 앞으로 오도록 역순 정렬
         new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
     );
   }, [messages]);
@@ -365,10 +380,10 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
         }
 
         // 페이지 로드 조건 명시적 확인
-        if (!isFetchingNextPage && hasNextPage) {
-          console.log('이전 메시지 로드 시도');
-          await fetchNextPage();
-        }
+        // if (!isFetchingNextPage && hasNextPage) {
+        //   console.log('이전 메시지 로드 시도');
+        //   await fetchNextPage();
+        // }
       } catch (error) {
         console.error('초기화 중 오류:', error);
       }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 회원 탈퇴
  - 회원 탈퇴 api 요청만 구현되어 있음
- 채팅
  - 첫 입장 시, 모든 이전 메시지가 한번에 로드됨
- 회원가입
  - 인증번호 메일 재전송 시 타이머가 변하지 않아, 사용자가 남은 시간을 확인하기 어려움
- 빌드 warning 해결
    - `img` 태그 사용
    - 의존성 배열 warnging

**TO-BE**
- 회원 탈퇴
  - 회원탈퇴 버튼 클릭 시 비밀번호 입력하여 확인 절차 거치도록 구현
  - ` 커스텀 Confirm` 창에서 조건에 따라 비밀번호 입력할 수 있도록 구현
- 채팅
  - 첫 입장 시 모든 이전 메시지 중 page=0(20개의 메시지)만 로드되도록 해결중
- 회원가입
  - 인증번호 메일 재전송 시 타이머 재시작하도록 수정
  **- 추후, 서버 시간을 활용하는 것으로 수정 예정**
- 빌드 warning 해결
  - `next/image` 의 `<Image />` 컴포넌트 사용하여 성능 개선
  - 의존성 배열 warning 해결
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] 회원 탈퇴 커스텀 confirm 창 뜨는 지 확인
- [X] 타이머 재시작 테스트