### PR TITLE
feat: 카드 디자인 통일, 스터디 생성 시 날짜 제한 적용

### DIFF
--- a/src/app/community/components/PostList.tsx
+++ b/src/app/community/components/PostList.tsx
@@ -51,7 +51,11 @@ export function PostList<T extends InfoPost | QnAPost>({
       ) : (
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {posts.map(post => renderPostCard(post))}
+            {posts.map(post => (
+              <div className="flex justify-center" key={post.id}>
+                {renderPostCard(post)}
+              </div>
+            ))}
           </div>
 
           {/* 페이지네이션 */}

--- a/src/app/community/study/[id]/components/StudyDetailContent.tsx
+++ b/src/app/community/study/[id]/components/StudyDetailContent.tsx
@@ -10,7 +10,7 @@ import StudyLocation from './StudyLocation';
 import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import StudyParticipants from './StudyParticipants';
-
+import { convertDifficultyToKorean, convertMeetingType } from '@/utils/study';
 interface StudyDetailContentProps {
   studyId: string;
 }
@@ -120,7 +120,7 @@ export default function StudyDetailContent({
         <div className="mb-6">
           <div className="grid grid-cols-2 gap-4 text-sm text-base-content/70">
             <p>스터디명: {study.studyName}</p>
-            <p>난이도: {study.difficulty}</p>
+            <p>난이도: {convertDifficultyToKorean(study.difficulty)}</p>
             <p>
               모집 기한: {dayjs(study.recruitmentPeriod).format('YYYY.MM.DD')}
               까지
@@ -137,7 +137,7 @@ export default function StudyDetailContent({
               스터디 시간: {study.startTime} ~ {study.endTime}
             </p>
             <p>스터디 요일: {study.dayType.join(', ')}</p>
-            <p>진행 방식: {study.meetingType}</p>
+            <p>진행 방식: {convertMeetingType(study.meetingType)}</p>
           </div>
         </div>
 

--- a/src/app/community/study/components/HybridStudyList.tsx
+++ b/src/app/community/study/components/HybridStudyList.tsx
@@ -172,12 +172,14 @@ export default function HybridStudyList() {
           userLocation={userLocation}
         />
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {isLoading ? (
           <div>로딩 중...</div>
         ) : posts?.content ? (
           posts.content.map((post: BaseStudyPost) => (
-            <StudyCard key={post.id} post={post} />
+            <div className="flex justify-center" key={post.id}>
+              <StudyCard post={post} />
+            </div>
           ))
         ) : (
           <div>데이터가 없습니다.</div>

--- a/src/app/community/study/components/OnlineStudyList.tsx
+++ b/src/app/community/study/components/OnlineStudyList.tsx
@@ -123,12 +123,14 @@ export default function OnlineStudyList() {
         selectedDays={selectedDays}
         onFilterChange={handleFilterChange}
       />
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {isLoading ? (
           <div>로딩 중...</div>
         ) : posts?.content ? (
           posts.content.map((post: StudyPost) => (
-            <StudyCard key={post.id} post={post} />
+            <div className="flex justify-center" key={post.id}>
+              <StudyCard post={post} />
+            </div>
           ))
         ) : (
           <div>데이터가 없습니다.</div>

--- a/src/app/community/study/components/StudyCard.tsx
+++ b/src/app/community/study/components/StudyCard.tsx
@@ -15,9 +15,19 @@ interface StudyCardProps {
 export function StudyCard({ post }: StudyCardProps) {
   const router = useRouter();
 
+  // 텍스트 길이 제한 함수
+  const truncateText = (text: string, maxLength: number) => {
+    return text.length > maxLength ? text.slice(0, maxLength) + '...' : text;
+  };
+
+  // 시간에서 :00을 제거하는 함수
+  const formatTime = (time: string) => {
+    return time.slice(0, 5); // "HH:mm:ss" -> "HH:mm"
+  };
+
   return (
     <div
-      className="card bg-base-100 shadow-xl cursor-pointer"
+      className="card bg-base-100 shadow-xl cursor-pointer hover:shadow-2xl transition-shadow w-full min-w-[320px] max-w-[320px]"
       onClick={() => router.push(`/community/study/${post.id}`)}
     >
       <figure className="px-4 pt-4">
@@ -30,38 +40,50 @@ export function StudyCard({ post }: StudyCardProps) {
         />
       </figure>
       <div className="card-body">
-        <h2 className="card-title text-lg">{post.title}</h2>
-        <div className="space-y-2 text-sm">
-          <div className="flex justify-between">
-            <span>모집 인원:</span>
+        <h2 className="card-title text-lg mb-4">
+          {truncateText(post.title, 20)}
+        </h2>
+
+        {/* 정보 뱃지 그리드 */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="badge badge-lg bg-primary/30 px-4 py-3 rounded-full">
+            {truncateText(convertSubjectToKorean(post.subject), 5)}
+          </div>
+          <div className="badge badge-lg bg-secondary/30 px-4 py-3 rounded-full">
+            난이도 {truncateText(convertDifficultyToKorean(post.difficulty), 5)}
+          </div>
+          <div className="badge badge-lg bg-accent/30 px-4 py-3 rounded-full">
+            {post.currentParticipants + 1}/{post.maxParticipants}명
+          </div>
+          <div className="badge badge-lg bg-info/30 px-4 py-3 rounded-full">
+            {truncateText(post.dayType.join(', '), 7)}
+          </div>
+        </div>
+
+        {/* 하단 시간 정보 */}
+        <div className="mt-4 text-sm flex flex-col gap-2">
+          <div className="flex justify-between items-center">
+            <span>모집 마감일</span>
+            <span>{dayjs(post.recruitmentPeriod).format('YY.MM.DD')}</span>
+          </div>
+          <div className="flex justify-between items-center">
+            <span>스터디 기간</span>
             <span>
-              {post.currentParticipants + 1}/{post.maxParticipants}명
+              {dayjs(post.startDate).format('YY.MM.DD')} ~{' '}
+              {dayjs(post.endDate).format('YY.MM.DD')}
             </span>
           </div>
-          <div className="flex justify-between">
-            <span>주제:</span>
-            <span>{convertSubjectToKorean(post.subject)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span>난이도:</span>
-            <span>{convertDifficultyToKorean(post.difficulty)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span>기간:</span>
+          <div className="flex justify-between items-center">
+            <span>스터디 시간</span>
             <span>
-              {dayjs(post.startDate).format('MM.DD')} ~{' '}
-              {dayjs(post.endDate).format('MM.DD')}
-            </span>
-          </div>
-          <div className="flex justify-between">
-            <span>시간:</span>
-            <span>
-              {post.startTime} ~ {post.endTime}
+              {formatTime(post.startTime)} ~ {formatTime(post.endTime)}
             </span>
           </div>
         </div>
-        <div className="card-actions justify-end mt-4">
-          <button className="btn btn-primary btn-sm">상세보기</button>
+
+        {/* 상세보기 버튼 */}
+        <div className="text-right mt-2">
+          <span className="text-sm hover:opacity-70">상세보기 →</span>
         </div>
       </div>
     </div>

--- a/src/app/community/study/components/StudyCard.tsx
+++ b/src/app/community/study/components/StudyCard.tsx
@@ -4,7 +4,10 @@ import { useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
 import { StudyPost } from '@/types/post';
 import Image from 'next/image';
-
+import {
+  convertSubjectToKorean,
+  convertDifficultyToKorean,
+} from '@/utils/study';
 interface StudyCardProps {
   post: StudyPost;
 }
@@ -37,11 +40,11 @@ export function StudyCard({ post }: StudyCardProps) {
           </div>
           <div className="flex justify-between">
             <span>주제:</span>
-            <span>{post.subject}</span>
+            <span>{convertSubjectToKorean(post.subject)}</span>
           </div>
           <div className="flex justify-between">
             <span>난이도:</span>
-            <span>{post.difficulty}</span>
+            <span>{convertDifficultyToKorean(post.difficulty)}</span>
           </div>
           <div className="flex justify-between">
             <span>기간:</span>

--- a/src/app/community/study/write/components/HybridForm.tsx
+++ b/src/app/community/study/write/components/HybridForm.tsx
@@ -299,6 +299,7 @@ export default function HybridForm({ initialData, isEdit }: HybridFormProps) {
           required
           className="input input-bordered"
           min={dayjs().format('YYYY-MM-DD')}
+          max={dayjs().add(1, 'month').format('YYYY-MM-DD')}
           onChange={e => setRecruitmentEndDate(e.target.value)}
         />
       </div>
@@ -315,6 +316,7 @@ export default function HybridForm({ initialData, isEdit }: HybridFormProps) {
             required
             className="input input-bordered flex-1"
             min={dayjs(recruitmentEndDate).format('YYYY-MM-DD')}
+            max={dayjs(recruitmentEndDate).add(7, 'day').format('YYYY-MM-DD')}
             onChange={e => setStudyStartDate(e.target.value)}
           />
           <span className="self-center">~</span>
@@ -325,6 +327,7 @@ export default function HybridForm({ initialData, isEdit }: HybridFormProps) {
             required
             className="input input-bordered flex-1"
             min={studyStartDate || dayjs().format('YYYY-MM-DD')}
+            max={dayjs(studyStartDate).add(60, 'day').format('YYYY-MM-DD')}
             disabled={!studyStartDate}
           />
         </div>

--- a/src/app/community/study/write/components/OnlineForm.tsx
+++ b/src/app/community/study/write/components/OnlineForm.tsx
@@ -283,6 +283,7 @@ export default function OnlineForm({ initialData, isEdit }: OnlineFormProps) {
           required
           className="input input-bordered"
           min={dayjs().format('YYYY-MM-DD')}
+          max={dayjs().add(1, 'month').format('YYYY-MM-DD')}
           onChange={e => setRecruitmentEndDate(e.target.value)}
         />
       </div>
@@ -298,7 +299,8 @@ export default function OnlineForm({ initialData, isEdit }: OnlineFormProps) {
             defaultValue={initialData?.startDate}
             required
             className="input input-bordered flex-1"
-            min={dayjs(recruitmentEndDate).format('YYYY-MM-DD')} // 모집 마감일 이후로 제한
+            min={dayjs(recruitmentEndDate).format('YYYY-MM-DD')}
+            max={dayjs(recruitmentEndDate).add(7, 'day').format('YYYY-MM-DD')}
             onChange={e => setStudyStartDate(e.target.value)}
           />
           <span className="self-center">~</span>
@@ -309,6 +311,7 @@ export default function OnlineForm({ initialData, isEdit }: OnlineFormProps) {
             required
             className="input input-bordered flex-1"
             min={studyStartDate || dayjs().format('YYYY-MM-DD')}
+            max={dayjs(studyStartDate).add(60, 'day').format('YYYY-MM-DD')}
             disabled={!studyStartDate}
           />
         </div>

--- a/src/app/mypage/components/MyInfoPostCard.tsx
+++ b/src/app/mypage/components/MyInfoPostCard.tsx
@@ -18,7 +18,7 @@ const MyInfoPostCard = ({ post }: MyPostCardProps) => {
 
   return (
     <div
-      className="card bg-base-100 shadow-xl cursor-pointer"
+      className="card bg-base-100 shadow-xl cursor-pointer hover:shadow-2xl transition-shadow w-full min-w-[320px] max-w-[320px]"
       onClick={() => router.push(`/community/info/${post.id}`)}
     >
       <figure className="px-4 pt-4">

--- a/src/app/mypage/components/MyQnAPostCard.tsx
+++ b/src/app/mypage/components/MyQnAPostCard.tsx
@@ -18,7 +18,7 @@ const MyQnAPostCard = ({ post }: MyPostCardProps) => {
 
   return (
     <div
-      className="card bg-base-100 shadow-xl cursor-pointer"
+      className="card bg-base-100 shadow-xl cursor-pointer hover:shadow-2xl transition-shadow w-full min-w-[320px] max-w-[320px]"
       onClick={() => router.push(`/community/qna/${post.id}`)}
     >
       <figure className="px-4 pt-4">

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -5,6 +5,11 @@ import dayjs from 'dayjs';
 import { useAuthStore } from '@/store/authStore';
 import axios from 'axios';
 import Image from 'next/image';
+import {
+  convertSubjectToKorean,
+  convertDifficultyToKorean,
+  convertStudyStatus,
+} from '@/utils/study';
 
 interface MyStudyCardProps {
   post: MyStudyCardData;
@@ -62,15 +67,15 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
         <div className="space-y-2 text-sm">
           <div className="flex justify-between">
             <span>상태:</span>
-            <span>{post.status}</span>
+            <span>{convertStudyStatus(post.status)}</span>
           </div>
           <div className="flex justify-between">
             <span>주제:</span>
-            <span>{post.subject}</span>
+            <span>{convertSubjectToKorean(post.subject)}</span>
           </div>
           <div className="flex justify-between">
             <span>난이도:</span>
-            <span>{post.difficulty}</span>
+            <span>{convertDifficultyToKorean(post.difficulty)}</span>
           </div>
           <div className="flex justify-between">
             <span>요일:</span>

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -43,7 +43,7 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
 
   return (
     <div
-      className="card bg-base-100 shadow-xl cursor-pointer"
+      className="card bg-base-100 shadow-xl cursor-pointer hover:shadow-2xl transition-shadow w-full min-w-[320px] max-w-[320px]"
       onClick={() => router.push(`/community/study/${post.studyPostId}`)}
     >
       <figure className="px-4 pt-4">

--- a/src/app/mypage/components/MyStudyView.tsx
+++ b/src/app/mypage/components/MyStudyView.tsx
@@ -143,9 +143,11 @@ const MyStudyView = () => {
       return <p>{currentTab.emptyMessage}</p>;
 
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-20">
         {currentTab.data.map((post: any) => (
-          <currentTab.component key={post.id} post={post} />
+          <div className="flex justify-center" key={post.id}>
+            <currentTab.component post={post} />
+          </div>
         ))}
       </div>
     );

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -36,10 +36,16 @@ export const MEETING_TYPE = {
   HYBRID: '병행',
 } as const;
 
-export const STATUS_OPTIONS = {
+export const RECRUITMENT_STATUS = {
   RECRUITING: '모집 중',
-  IN_PROGRESS: '진행 중',
+  CLOSED: '모집 완료',
   CANCELED: '모집 취소',
+} as const;
+
+export const STUDY_STATUS = {
+  PENDING: '대기',
+  IN_PROGRESS: '진행 중',
+  COMPLETED: '진행 종료',
 } as const;
 
 export const DAY_KOREAN = {

--- a/src/utils/study.ts
+++ b/src/utils/study.ts
@@ -1,4 +1,11 @@
 import { StudyDifficulty, StudySubject } from '@/types/study';
+import {
+  SUBJECT_OPTIONS,
+  DIFFICULTY_OPTIONS,
+  MEETING_TYPE,
+  RECRUITMENT_STATUS,
+  STUDY_STATUS,
+} from '@/types/study';
 
 export const convertDifficulty = (difficulty: string): StudyDifficulty => {
   const difficultyMap: Record<string, StudyDifficulty> = {
@@ -19,4 +26,41 @@ export const convertSubject = (subject: string): StudySubject => {
     기타: 'ETC',
   };
   return subjectMap[subject];
+};
+
+// 상태 변환 (RECRUITING -> 모집 중)
+export const convertStatus = (status: string): string => {
+  return (
+    RECRUITMENT_STATUS[status as keyof typeof RECRUITMENT_STATUS] || status
+  );
+};
+
+// 미팅 타입 변환 (ONLINE -> 온라인)
+export const convertMeetingType = (type: string): string => {
+  return MEETING_TYPE[type as keyof typeof MEETING_TYPE] || type;
+};
+
+// 난이도 변환 (HIGH -> 상)
+export const convertDifficultyToKorean = (difficulty: string): string => {
+  return (
+    DIFFICULTY_OPTIONS[difficulty as keyof typeof DIFFICULTY_OPTIONS] ||
+    difficulty
+  );
+};
+
+// 주제 변환 (CONCEPT_LEARNING -> 개념학습)
+export const convertSubjectToKorean = (subject: string): string => {
+  return SUBJECT_OPTIONS[subject as keyof typeof SUBJECT_OPTIONS] || subject;
+};
+
+// 모집글 상태 변환
+export const convertRecruitmentStatus = (status: string): string => {
+  return (
+    RECRUITMENT_STATUS[status as keyof typeof RECRUITMENT_STATUS] || status
+  );
+};
+
+// 스터디 진행 상태 변환
+export const convertStudyStatus = (status: string): string => {
+  return STUDY_STATUS[status as keyof typeof STUDY_STATUS] || status;
 };


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**

- 스터디 카드의 디자인이 일정하지 않음
- 스터디 생성 시 날짜 선택의 제한이 없음

**TO-BE**

- 스터디 카드 디자인을 유저 친화적으로 변경
- 카드의 크기를 통일
- 카드에 필요한 정보들을 표기
- 스터디 글 작성 시 캘린더 상에서 날짜를 제한시킴 
- (모집 기간 최대 30일, 스터디 시작일은 모집 마감으로부터 최대 7일, 스터디 종료까지는 최대 60일)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 반응형 테스트
- [x] API 테스트
