### PR TITLE
fix: signinType에 따른 회원탈퇴,비밀번호 변경 백엔드 요청 에러 해결 / 채팅방 재입장 시 실시간 메시지 로드 에러 해결 / 채팅방, 내가 속한 스터디 디자인 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,10 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['devonoffbucket.s3.ap-northeast-2.amazonaws.com'], // 외부 이미지 도메인 추가
+    domains: [
+      'devonoffbucket.s3.ap-northeast-2.amazonaws.com',
+      'swany-bucket.s3.ap-northeast-2.amazonaws.com',
+    ], // 외부 이미지 도메인 추가
   },
   async headers() {
     return [

--- a/src/app/api/auth/change-password/[userId]/route.ts
+++ b/src/app/api/auth/change-password/[userId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+export const POST = async (request: NextRequest) => {
+  const { currentPassword, newPassword } = await request.json();
+  const userId = request.nextUrl.pathname.split('/')[4] as string;
+
+  try {
+    const response = await axios.post(
+      `${process.env.API_URL}/auth/change-password/${userId}`,
+      { currentPassword, newPassword },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (response.status === 200) {
+      return NextResponse.json(response.data, { status: response.status });
+    }
+  } catch (error: any) {
+    if (error.response) {
+      const { status, data } = error.response;
+      return NextResponse.json(data, { status });
+    }
+
+    return NextResponse.json(
+      { message: '네트워크 오류가 발생했습니다.' },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/auth/sign-out/route.ts
+++ b/src/app/api/auth/sign-out/route.ts
@@ -14,6 +14,7 @@ export const POST = async () => {
         { status: 200 },
       );
     }
+    // 액세스 토큰 재발급
     try {
       const reissueResponse = await axios.post(
         `${process.env.API_URL}/auth/token-reissue`, // 백엔드로 바로 요청
@@ -24,15 +25,16 @@ export const POST = async () => {
 
       if (reissueResponse.status === 200) {
         accessToken = reissueResponse.data.accessToken;
+        console.log('Reissue Response:', reissueResponse);
       } else {
         return NextResponse.json(
-          { errorMessage: 'sign-out route.ts 액세스 토큰 재발급 실패' },
+          { errorMessage: '액세스 토큰 재발급 실패' },
           { status: 500 },
         );
       }
     } catch (error) {
       return NextResponse.json(
-        { errorMessage: 'catch 문 액세스 토큰 재발급 실패', error },
+        { errorMessage: '액세스 토큰 재발급 실패', error },
         { status: 500 },
       );
     }

--- a/src/app/api/auth/withdrawal/route.ts
+++ b/src/app/api/auth/withdrawal/route.ts
@@ -1,35 +1,70 @@
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
+import { deleteCookie } from '@/utils/cookies';
 import { cookies } from 'next/headers';
 
 export const POST = async (req: NextRequest) => {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
+  let accessToken = cookieStore.get('accessToken')?.value;
 
   const { password } = await req.json();
 
-  try {
-    await axios.post(
-      `${process.env.API_URL}/auth/withdrawal`,
-      { password },
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${accessToken}`,
+  if (!accessToken) {
+    const refreshToken = cookieStore.get('refreshToken')?.value;
+    if (!refreshToken) {
+      return NextResponse.json(
+        { message: '다시 로그인 해주세요.' },
+        { status: 403 },
+      );
+    }
+    // 액세스 토큰 재발급
+    try {
+      const reissueResponse = await axios.post(
+        `${process.env.API_URL}/auth/token-reissue`, // 백엔드로 바로 요청
+        {
+          refreshToken,
         },
+      );
+
+      if (reissueResponse.status === 200) {
+        accessToken = reissueResponse.data.accessToken;
+        console.log('Reissue Response:', reissueResponse);
+      } else {
+        return NextResponse.json(
+          { errorMessage: '액세스 토큰 재발급 실패' },
+          { status: 500 },
+        );
+      }
+    } catch (error) {
+      return NextResponse.json(
+        { errorMessage: '액세스 토큰 재발급 실패', error },
+        { status: 500 },
+      );
+    }
+  }
+
+  try {
+    const config = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
       },
-    );
+    };
+
+    const payload = password ? { password } : undefined;
+
+    await axios.post(`${process.env.API_URL}/auth/withdrawal`, payload, config);
+
     const res = NextResponse.json({ message: '회원 탈퇴 성공' });
 
-    // deleteCookie(res, 'accessToken');
-    // deleteCookie(res, 'refreshToken');
-    res.cookies.set('accessToken', '', { maxAge: 0 });
-    res.cookies.set('refreshToken', '', { maxAge: 0 });
+    deleteCookie(res, 'accessToken');
+    deleteCookie(res, 'refreshToken');
 
-    return NextResponse.json(
-      { message: '회원 탈퇴 성공' },
-      { headers: res.headers },
-    );
+    // return NextResponse.json(
+    //   { message: '회원 탈퇴 성공' },
+    //   { headers: res.headers },
+    // );
+    return res;
   } catch (error: any) {
     if (error.response) {
       const { status, data } = error.response;

--- a/src/app/api/users/[userId]/profile-image/route.ts
+++ b/src/app/api/users/[userId]/profile-image/route.ts
@@ -22,8 +22,15 @@ export const POST = async (request: NextRequest) => {
     );
 
     if (response.status === 200) {
-      const { id, nickname, email, profileImageUrl } = response.data;
-      const updatedUserInfo = { id, nickname, email, profileImageUrl };
+      const { id, nickname, email, profileImageUrl, signinType } =
+        response.data;
+      const updatedUserInfo = {
+        id,
+        nickname,
+        email,
+        profileImageUrl,
+        signinType,
+      };
       console.log('response data:', updatedUserInfo);
       return NextResponse.json(updatedUserInfo, { status: response.status });
     }
@@ -53,8 +60,15 @@ export const DELETE = async (request: NextRequest) => {
     );
 
     if (response.status === 200) {
-      const { id, nickname, email, profileImageUrl } = response.data;
-      const updatedUserInfo = { id, nickname, email, profileImageUrl };
+      const { id, nickname, email, profileImageUrl, signinType } =
+        response.data;
+      const updatedUserInfo = {
+        id,
+        nickname,
+        email,
+        profileImageUrl,
+        signinType,
+      };
       return NextResponse.json(updatedUserInfo, { status: response.status });
     }
   } catch (error: any) {

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -24,8 +24,15 @@ export const PUT = async (request: NextRequest) => {
     );
 
     if (response.status === 200) {
-      const { id, nickname, email, profileImageUrl } = response.data;
-      const updatedUserInfo = { id, nickname, email, profileImageUrl };
+      const { id, nickname, email, profileImageUrl, signinType } =
+        response.data;
+      const updatedUserInfo = {
+        id,
+        nickname,
+        email,
+        profileImageUrl,
+        signinType,
+      };
       return NextResponse.json(updatedUserInfo, { status: response.status });
     }
   } catch (error: any) {

--- a/src/app/chat/[chatRoomId]/study/[studyId]/page.tsx
+++ b/src/app/chat/[chatRoomId]/study/[studyId]/page.tsx
@@ -12,8 +12,6 @@ const ChatPage = async ({ params }: ChatPageProps) => {
 
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">채팅</h1>
-
       <div className="mt-4">
         <ChatRoom chatRoomId={chatRoomId} studyId={studyId} />
       </div>

--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -12,9 +12,9 @@ interface ChatRoomProps {
 }
 
 const ChatRoom = ({ chatRoomId, studyId }: ChatRoomProps) => {
+  console.log('studyId', studyId);
   const searchParams = useSearchParams();
   const studyName = searchParams.get('studyName');
-  console.log('studyId: ', studyId, 'studyName: ', studyName);
 
   const { userInfo } = useAuthStore();
   const userId = userInfo?.id || 111;
@@ -35,7 +35,7 @@ const ChatRoom = ({ chatRoomId, studyId }: ChatRoomProps) => {
 
   const { ref, inView } = useInView({
     triggerOnce: false,
-    threshold: 0,
+    threshold: 0.1,
   });
 
   const handleFetchPreviousMessages = async () => {
@@ -123,89 +123,102 @@ const ChatRoom = ({ chatRoomId, studyId }: ChatRoomProps) => {
   };
 
   return (
-    <div className="flex flex-col h-[600px] bg-white rounded-lg p-4 shadow-md">
-      <div
-        ref={chatContainerRef}
-        className="flex-1 overflow-y-auto space-y-4 pb-4"
-      >
-        {isFetchingNextPage && (
-          <div className="text-center text-gray-500 py-2">
-            이전 메시지 로딩 중...
+    <div className="flex justify-center items-start h-screen">
+      <div className="mt-4 w-[80%] max-w-5xl bg-white rounded-lg shadow-lg relative overflow-hidden">
+        <div className="bg-gray-900 text-gray-100 p-4 flex items-center gap-2">
+          <div className="bg-red-500 w-3 h-3 rounded-full"></div>
+          <div className="bg-yellow-500 w-3 h-3 rounded-full"></div>
+          <div className="bg-green-500 w-3 h-3 rounded-full"></div>
+        </div>
+        <div className="flex items-center bg-gray-100 p-3 border-b border-gray-300">
+          <div className="w-full text-lg text-center font-bold focus:outline-none bg-white border border-gray-300 rounded-md p-2">
+            {studyName}
           </div>
-        )}
-        {loadError && !isFetchingNextPage && (
-          <div className="text-center text-red-500">{loadError}</div>
-        )}
+        </div>
+        <div
+          ref={chatContainerRef}
+          className="flex-1 h-[500px] overflow-y-auto space-y-4 px-6 pb-6"
+        >
+          {isFetchingNextPage && (
+            <div className="text-center text-gray-500 py-2">
+              이전 메시지 로딩 중...
+            </div>
+          )}
+          {loadError && !isFetchingNextPage && (
+            <div className="text-center text-red-500">{loadError}</div>
+          )}
 
-        {messages.length === 0 && !isFetchingNextPage && (
-          <div className="text-center text-gray-500">메시지가 없습니다.</div>
-        )}
+          {messages.length === 0 && !isFetchingNextPage && (
+            <div className="text-center text-gray-500">메시지가 없습니다.</div>
+          )}
 
-        {messages.map((msg, idx) => {
-          const prevMessage = messages[idx - 1] || null;
-          const showDate =
-            !prevMessage ||
-            isDateChanged(msg.timestamp, prevMessage?.timestamp);
+          {messages.map((msg, idx) => {
+            const prevMessage = messages[idx - 1] || null;
+            const showDate =
+              !prevMessage ||
+              isDateChanged(msg.timestamp, prevMessage?.timestamp);
 
-          return (
-            <div key={msg.timestamp || idx}>
-              {/* 날짜 구분 라인 */}
-              {showDate && (
-                <div className="text-center text-gray-500 text-xs my-2">
-                  {new Date(msg.timestamp).toLocaleDateString('ko-KR', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </div>
-              )}
-
-              {/* 채팅 메시지 */}
-              <div
-                className={`flex items-end gap-2 ${
-                  msg.user.id === userId ? 'justify-end' : 'justify-start'
-                }`}
-              >
-                {/* 상대방 프로필 이미지 및 유저 ID */}
-                {msg.user.id !== userId && (
-                  <div className="flex flex-col items-center">
-                    <img
-                      src={
-                        msg.user.profileImageUrl ||
-                        'http://via.placeholder.com/150'
-                      }
-                      alt={`${msg.user.id}'s profile`}
-                      className="w-8 h-8 rounded-full"
-                    />
-                    <div
-                      className="text-xs text-gray-600 truncate max-w-[100px] nickname"
-                      title={msg.user.nickname}
-                    >
-                      {msg.user.nickname}
-                    </div>
+            return (
+              <div key={msg.timestamp || idx}>
+                {/* 날짜 구분 라인 */}
+                {showDate && (
+                  <div className="text-center text-gray-500 text-sm">
+                    {new Date(msg.timestamp).toLocaleDateString('ko-KR', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
                   </div>
                 )}
 
-                {/* 메시지 말풍선 */}
+                {/* 채팅 메시지 */}
                 <div
-                  className={`relative max-w-[70%] px-4 py-2 rounded-lg ${
-                    msg.user.id === userId
-                      ? 'bg-blue-500 text-white self-end'
-                      : 'bg-gray-200 text-black'
+                  className={`flex items-end ${
+                    msg.user.id === userId ? 'justify-end' : 'justify-start'
                   }`}
                 >
-                  <div>{msg.content}</div>
+                  {/* 상대방 프로필 이미지 및 유저 ID */}
+                  {msg.user.id !== userId && (
+                    <div className="flex flex-col items-center">
+                      <img
+                        src={
+                          msg.user.profileImageUrl ||
+                          'http://via.placeholder.com/150'
+                        }
+                        alt={`${msg.user.id}'s profile`}
+                        className="w-8 h-8 sm:w-10 sm:h-10 rounded-full"
+                      />
+                      <div
+                        className="text-xs text-gray-600 truncate max-w-[70px] nickname"
+                        title={msg.user.nickname}
+                      >
+                        {msg.user.nickname}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* 메시지 말풍선 */}
                   <div
-                    className={`mt-2 text-xs ${
-                      msg.user.id === userId ? 'text-gray-300' : 'text-gray-500'
+                    className={`relative max-w-[70%] px-4 py-2 rounded-lg ${
+                      msg.user.id === userId
+                        ? 'bg-blue-500 text-white self-end'
+                        : 'bg-gray-200 text-black'
                     }`}
                   >
-                    {new Date(msg.timestamp).toLocaleTimeString('ko-KR', {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
-                  </div>
-                  {/* {msg.imgUrl && (
+                    <div>{msg.content}</div>
+                    <div
+                      className={`mt-2 text-xs sm:text-sm ${
+                        msg.user.id === userId
+                          ? 'text-gray-300'
+                          : 'text-gray-500'
+                      }`}
+                    >
+                      {new Date(msg.timestamp).toLocaleTimeString('ko-KR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </div>
+                    {/* {msg.imgUrl && (
                     <img
                       src={msg.imgUrl}
                       alt="첨부 이미지"
@@ -213,47 +226,50 @@ const ChatRoom = ({ chatRoomId, studyId }: ChatRoomProps) => {
                     />
                   )} */}
 
-                  {/* 말풍선 꼬리 */}
-                  <div
-                    className={`absolute bottom-0 w-0 h-0 border-t-[10px] ${
-                      msg.user.id === userId
-                        ? 'border-blue-500 right-[-6px] border-r-[10px] border-r-transparent'
-                        : 'border-gray-200 left-[-6px] border-l-[10px] border-l-transparent'
-                    }`}
-                  />
-                </div>
-
-                {/* 자신의 프로필 이미지 및 유저 ID */}
-                {msg.user.id === userId && (
-                  <div className="flex flex-col items-center">
-                    <img
-                      src={
-                        msg.user.profileImageUrl ||
-                        'http://via.placeholder.com/150'
-                      }
-                      alt="My profile"
-                      className="w-8 h-8 rounded-full"
-                    />
+                    {/* 말풍선 꼬리 */}
                     <div
-                      className="text-xs text-gray-600 truncate max-w-[100px] nickname"
-                      title={msg.user.nickname}
-                    >
-                      {msg.user.nickname}
-                    </div>
+                      className={`absolute bottom-0 w-0 h-0 border-t-[10px] ${
+                        msg.user.id === userId
+                          ? 'border-blue-500 right-[-6px] border-r-[10px] border-r-transparent'
+                          : 'border-gray-200 left-[-6px] border-l-[10px] border-l-transparent'
+                      }`}
+                    />
                   </div>
-                )}
-              </div>
-            </div>
-          );
-        })}
-        {/* 스크롤이 최상단에 도달하면 트리거 됨 */}
-        {hasNextPage && !isFetchingNextPage && (
-          <div ref={ref} className="h-1"></div>
-        )}
-      </div>
 
-      {/* 메시지 입력 */}
-      <MessageInput onSendMessage={sendMessage} />
+                  {/* 자신의 프로필 이미지 및 유저 ID */}
+                  {msg.user.id === userId && (
+                    <div className="flex flex-col items-center">
+                      <img
+                        src={
+                          msg.user.profileImageUrl ||
+                          'http://via.placeholder.com/150'
+                        }
+                        alt="My profile"
+                        className="w-8 h-8 sm:w-10 sm:h-10 rounded-full"
+                      />
+                      <div
+                        className="text-xs text-gray-600 truncate max-w-[70px] nickname"
+                        title={msg.user.nickname}
+                      >
+                        {msg.user.nickname}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+          {/* 스크롤이 최상단에 도달하면 트리거 됨 */}
+          {hasNextPage && !isFetchingNextPage && (
+            <div ref={ref} className="h-1"></div>
+          )}
+        </div>
+
+        {/* 메시지 입력 */}
+        <div className="p-6 border-t border-gray-300">
+          <MessageInput onSendMessage={sendMessage} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/app/chat/components/MessageInput.tsx
+++ b/src/app/chat/components/MessageInput.tsx
@@ -56,6 +56,12 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
           ref={messageInputRef}
           value={content}
           onChange={e => setContent(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleSubmit(e);
+            }
+          }}
           onInput={e => {
             const target = e.target as HTMLTextAreaElement;
             target.style.height = 'auto'; // 높이를 초기화

--- a/src/app/middlewares/pathConstants.ts
+++ b/src/app/middlewares/pathConstants.ts
@@ -13,4 +13,5 @@ export const IGNORED_PATHS = [
   '/api/auth/status',
   '/api/auth/token-reissue',
   '/api/study/author/*',
+  '/api/auth/withdrawal',
 ];

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import { useAuthStore } from '@/store/authStore';
 import axios from 'axios';
 import Image from 'next/image';
+import { FaCrown } from 'react-icons/fa';
 import {
   convertSubjectToKorean,
   convertDifficultyToKorean,
@@ -98,9 +99,10 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
         <h2 className="card-title text-lg items-center">
           {post.studyName}
           {userInfo?.id === post.studyLeaderId && (
-            <span className="badge bg-yellow-300 ml-2 rounded-full py-1 px-3 font-bold text-white shadow-md hover:bg-accent-focus transition">
-              스터디장
-            </span>
+            <div className="absolute top-4 right-4 flex flex-col items-center space-y-1 bg-rose-500 p-2 rounded-lg shadow-md">
+              <FaCrown className="text-white text-2xl" />
+              <span className="text-white text-xs font-bold">스터디장</span>
+            </div>
           )}
         </h2>
         <div className="space-y-2 text-sm">
@@ -139,9 +141,6 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
             className="btn btn-primary btn-sm"
             onClick={async e => {
               e.stopPropagation();
-              // router.push(
-              //   `/chat/${1}/study/${1}?studyName=${encodeURIComponent('코테 스터디')}`,
-              // );
               try {
                 const response = await axios.post(
                   `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/chat/study/${post.id}/participant/${userInfo?.id}`,

--- a/src/components/common/Confirm/index.tsx
+++ b/src/components/common/Confirm/index.tsx
@@ -8,8 +8,14 @@ type CustomConfirmProps = {
   onConfirm: () => void;
   onCancel: () => void;
   requirePasswordInput?: boolean;
-  inputValue?: string;
-  onInputChange?: (value: string) => void;
+  requireNewPasswordInput?: boolean;
+  requireConfirmPasswordInput?: boolean;
+  currentPasswordValue?: string;
+  newPasswordValue?: string;
+  confirmPasswordValue?: string;
+  onCurrentPasswordChange?: (value: string) => void;
+  onNewPasswordChange?: (value: string) => void;
+  onConfirmPasswordChange?: (value: string) => void;
 };
 
 const CustomConfirm = ({
@@ -17,8 +23,14 @@ const CustomConfirm = ({
   onConfirm,
   onCancel,
   requirePasswordInput = false,
-  inputValue = '',
-  onInputChange = () => {},
+  requireNewPasswordInput = false,
+  requireConfirmPasswordInput = false,
+  currentPasswordValue = '',
+  newPasswordValue = '',
+  confirmPasswordValue = '',
+  onCurrentPasswordChange = () => {},
+  onNewPasswordChange = () => {},
+  onConfirmPasswordChange = () => {},
 }: CustomConfirmProps) => {
   useEffect(() => {
     const handleOutsideClick = (e: MouseEvent) => {
@@ -30,11 +42,21 @@ const CustomConfirm = ({
     return () => document.removeEventListener('click', handleOutsideClick);
   }, [onCancel]);
 
-  const [passwordVisible, setPasswordVisible] = useState(false);
-  const togglePasswordVisibility = () => {
-    setPasswordVisible(!passwordVisible);
+  const [currentPasswordVisible, setCurrentPasswordVisible] = useState(false);
+  const [newPasswordVisible, setNewPasswordVisible] = useState(false);
+  const [confirmPasswordVisible, setConfirmPasswordVisible] = useState(false);
+
+  const toggleCurrentPasswordVisibility = () => {
+    setCurrentPasswordVisible(!currentPasswordVisible);
   };
 
+  const toggleNewPasswordVisibility = () => {
+    setNewPasswordVisible(!newPasswordVisible);
+  };
+
+  const toggleConfirmPasswordVisibility = () => {
+    setConfirmPasswordVisible(!confirmPasswordVisible);
+  };
   return (
     <div
       id="custom-confirm"
@@ -45,20 +67,66 @@ const CustomConfirm = ({
           {message}
         </p>
         {requirePasswordInput && (
-          <div className="relative">
+          <div className="relative mb-4">
             <input
-              type={passwordVisible ? 'text' : 'password'}
-              value={inputValue}
-              onChange={e => onInputChange(e.target.value)}
-              placeholder="비밀번호를 입력해주세요"
+              type={currentPasswordVisible ? 'text' : 'password'}
+              value={currentPasswordValue}
+              onChange={e => onCurrentPasswordChange(e.target.value)}
+              placeholder="현재 비밀번호를 입력해주세요"
               className="w-full input input-bordered px-4 py-2 focus:outline-indigo-500 text-sm sm:text-base"
             />
             <button
               type="button"
-              onClick={togglePasswordVisibility}
+              onClick={toggleCurrentPasswordVisibility}
               className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
             >
-              {passwordVisible ? (
+              {currentPasswordVisible ? (
+                <FaRegEye size={20} />
+              ) : (
+                <FaRegEyeSlash size={20} />
+              )}
+            </button>
+          </div>
+        )}
+
+        {requireNewPasswordInput && (
+          <div className="relative mb-4">
+            <input
+              type={newPasswordVisible ? 'text' : 'password'}
+              value={newPasswordValue}
+              onChange={e => onNewPasswordChange(e.target.value)}
+              placeholder="새 비밀번호를 입력해주세요"
+              className="w-full input input-bordered px-4 py-2 focus:outline-indigo-500 text-sm sm:text-base"
+            />
+            <button
+              type="button"
+              onClick={toggleNewPasswordVisibility}
+              className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+            >
+              {newPasswordVisible ? (
+                <FaRegEye size={20} />
+              ) : (
+                <FaRegEyeSlash size={20} />
+              )}
+            </button>
+          </div>
+        )}
+
+        {requireConfirmPasswordInput && (
+          <div className="relative mb-4">
+            <input
+              type={confirmPasswordVisible ? 'text' : 'password'}
+              value={confirmPasswordValue}
+              onChange={e => onConfirmPasswordChange(e.target.value)}
+              placeholder="새 비밀번호 확인"
+              className="w-full input input-bordered px-4 py-2 focus:outline-indigo-500 text-sm sm:text-base"
+            />
+            <button
+              type="button"
+              onClick={toggleConfirmPasswordVisibility}
+              className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+            >
+              {confirmPasswordVisible ? (
                 <FaRegEye size={20} />
               ) : (
                 <FaRegEyeSlash size={20} />

--- a/src/hooks/useGroupChat.ts
+++ b/src/hooks/useGroupChat.ts
@@ -1,5 +1,379 @@
-import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+// import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+// import { useInfiniteQuery } from '@tanstack/react-query';
+// import { Client } from '@stomp/stompjs';
+// import SockJS from 'sockjs-client';
+// import axios from 'axios';
+// import { User } from '@/types/post';
+
+// interface UseGroupChatParams {
+//   chatRoomId: string;
+//   userId: number;
+// }
+
+// interface ChatMessage {
+//   id: number;
+//   chatRoomId: number;
+//   content: string;
+//   createdAt: string;
+//   timestamp: string;
+//   user: User;
+// }
+
+// interface ChatState {
+//   isConnected: boolean;
+//   error: string | null;
+// }
+
+// const fetchChatMessages = async ({
+//   pageParam,
+//   chatRoomId,
+//   signal,
+// }: {
+//   pageParam: number;
+//   chatRoomId: string;
+//   signal: AbortSignal;
+// }): Promise<{
+//   messages: ChatMessage[];
+//   page: number;
+//   hasNextPage: boolean;
+// }> => {
+//   try {
+//     const response = await axios.get(
+//       `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/chat/${chatRoomId}/messages`,
+//       {
+//         params: { page: pageParam },
+//         signal,
+//       },
+//     );
+//     const { content, pageable, last } = response.data;
+
+//     // const hasMorePages = pageParam === 0 ? false : !last;
+//     const hasMorePages = pageParam === 0 ? true : !last;
+
+//     return {
+//       messages: content.map((msg: ChatMessage) => ({
+//         ...msg,
+//         timestamp: msg.createdAt, // createdAt 필드를 timestamp로 매핑
+//       })),
+//       page: pageable.pageNumber,
+//       hasNextPage: hasMorePages, // last 필드를 hasNextPage로 사용
+//     };
+//   } catch (error) {
+//     console.error('이전 메시지를 로드하는 데 실패했습니다.', error);
+
+//     return {
+//       messages: [], // 빈 배열 반환
+//       page: pageParam, // 현재 페이지 반환
+//       hasNextPage: false, // 더 이상 페이지가 없다고 표시a
+//     };
+//   }
+// };
+
+// export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
+//   const {
+//     data: fetchedData,
+//     hasNextPage,
+//     fetchNextPage,
+//     isFetchingNextPage,
+//   } = useInfiniteQuery({
+//     queryKey: ['chatMessages', chatRoomId], // queryKey를 객체 형태로 제공
+//     queryFn: async ({
+//       pageParam = 0,
+//       signal,
+//     }: {
+//       pageParam: number;
+//       signal: AbortSignal;
+//     }) => fetchChatMessages({ pageParam, chatRoomId, signal }),
+//     getNextPageParam: (lastPage: any, allPages: any) => {
+//       // const firstPage = allPages[0];
+//       console.log('lastPage', lastPage);
+//       return lastPage.hasNextPage ? lastPage.page + 1 : undefined;
+//     },
+
+//     initialPageParam: 0,
+//     staleTime: Infinity,
+//     gcTime: 1000 * 60 * 60,
+//     maxPages: 1,
+//     enabled: true, // 초기 자동 로드 방지
+//   });
+
+//   console.log('isFetchingNextPage: ', isFetchingNextPage);
+
+//   const loadInitialMessages = useCallback(async () => {
+//     try {
+//       await fetchNextPage();
+//     } catch (error) {
+//       console.error('Initial messages load failed:', error);
+//     }
+//   }, [fetchNextPage]);
+
+//   useEffect(() => {
+//     if (hasNextPage && !isFetchingNextPage) {
+//       loadInitialMessages();
+//     }
+//   }, [chatRoomId, hasNextPage, isFetchingNextPage, loadInitialMessages]);
+
+//   useEffect(() => {
+//     if (fetchedData) {
+//       const allMessages = fetchedData.pages.flatMap(page => page.messages);
+//       setMessages(prevMessages => {
+//         // 중복 제거 및 정렬
+//         const uniqueMessages = Array.from(
+//           new Map(
+//             [...prevMessages, ...allMessages].map(m => [m.id, m]),
+//           ).values(),
+//         ).sort(
+//           (a, b) =>
+//             new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+//         );
+
+//         console.log('Updated messages:', uniqueMessages);
+//         return uniqueMessages;
+//       });
+//     }
+//   }, [fetchedData]);
+
+//   const stompClient = useRef<Client | null>(null); // stompClient는 STOMP 클라이언트를 생성한 후, WebSocket 연결을 관리
+//   const [messages, setMessages] = useState<ChatMessage[]>([]);
+//   const [chatState, setChatState] = useState<ChatState>({
+//     isConnected: false, // 현재 연결 상태
+//     error: null, // 에러 발생 시 에러 정보 저장
+//   });
+
+//   const isConnecting = useRef(false);
+
+//   // const messagesWithoutDuplicates = useMemo(() => {
+//   //   // 중복 제거 및 정렬 로직
+//   //   return Array.from(new Map(messages.map(m => [m.id, m])).values()).sort(
+//   //     (a, b) =>
+//   //       new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+//   //   );
+//   // }, [messages]);
+//   const messagesWithoutDuplicates = useMemo(() => {
+//     return Array.from(new Map(messages.map(m => [m.id, m])).values()).sort(
+//       (a, b) =>
+//         // 오래된 메시지가 앞으로 오도록 역순 정렬
+//         new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+//     );
+//   }, [messages]);
+
+//   const connect = useCallback(async () => {
+//     console.log('connect 함수 호출됨', {
+//       time: new Date().toISOString(),
+//       stompClientExists: !!stompClient.current,
+//       chatRoomId,
+//     });
+
+//     if (isConnecting.current || stompClient.current?.connected) {
+//       console.log('연결 중복 방지 조건 확인', {
+//         isConnecting: isConnecting.current,
+//         isAlreadyConnected: stompClient.current?.connected,
+//       });
+//       return;
+//     }
+
+//     isConnecting.current = true;
+//     setChatState(prev => ({ ...prev, error: null }));
+
+//     try {
+//       const socket = new SockJS(
+//         `${process.env.NEXT_PUBLIC_CHAT_SOCKET_URL}/ws` as string,
+//       );
+//       console.log('SockJS 생성 완료', {
+//         socketState: socket.readyState, // 0: connecting, 1: open, 2: closing, 3: closed
+//       });
+
+//       await new Promise<void>((resolve, reject) => {
+//         const client = new Client({
+//           webSocketFactory: () => socket, // SockJS를 사용하여 WebSocket 연결 생성
+//           reconnectDelay: 5000, // SockJS를 사용하여 WebSocket 연결 생성
+//           heartbeatIncoming: 4000, // SockJS를 사용하여 WebSocket 연결 생성
+//           heartbeatOutgoing: 4000, // SockJS를 사용하여 WebSocket 연결 생성
+
+//           debug: msg => {
+//             console.log('STOMP Debug:', msg);
+//           },
+
+//           onConnect: () => {
+//             console.log('onConnect 실행', {
+//               time: new Date().toISOString(),
+//               socketState: socket.readyState,
+//               clientConnected: client.connected,
+//             });
+
+//             try {
+//               client.subscribe(`/topic/chat/${chatRoomId}`, messageOutput => {
+//                 console.log('WebSocket 메시지 수신:', messageOutput.body);
+
+//                 const newMessage = JSON.parse(
+//                   messageOutput.body,
+//                 ) as ChatMessage;
+
+//                 // timestamp 필드 보장
+//                 newMessage.timestamp = newMessage.createdAt;
+
+//                 setMessages(prevMessages => {
+//                   // 중복 체크 로직 유지
+//                   const isDuplicate = prevMessages.some(
+//                     msg => msg.id === newMessage.id,
+//                   );
+//                   if (isDuplicate) return prevMessages;
+
+//                   const updatedMessages = [...prevMessages, newMessage].sort(
+//                     (a, b) =>
+//                       new Date(a.timestamp).getTime() -
+//                       new Date(b.timestamp).getTime(),
+//                   );
+
+//                   console.log('메시지 상태 업데이트:', updatedMessages);
+//                   return updatedMessages;
+//                 });
+//               });
+//             } catch (error) {
+//               console.error('구독 실패:', error);
+//             }
+
+//             setChatState({
+//               isConnected: true,
+//               error: null,
+//             });
+//             isConnecting.current = false;
+//             resolve();
+//           },
+
+//           onDisconnect: () => {
+//             console.log('WebSocket 연결 해제됨');
+//             setChatState(prev => ({ ...prev, isConnected: false }));
+//           },
+
+//           onStompError: frame => {
+//             console.error('STOMP 에러 발생:', {
+//               headers: frame.headers,
+//               body: frame.body,
+//               command: frame.command,
+//             });
+
+//             reject(
+//               new Error(frame.headers.message || '연결 오류가 발생했습니다.'),
+//             );
+//           },
+//         });
+
+//         stompClient.current = client;
+//         console.log('client.activate() 호출 전');
+//         client.activate(); // 웹소켓 연결이 시작됨 -> 연결이 성공하면 onConnect 콜백이 실행됨
+//         console.log('client.activate() 호출 후');
+//       });
+//     } catch (error) {
+//       console.log('연결 실패', {
+//         error,
+//         time: new Date().toISOString(),
+//       });
+
+//       setChatState(prev => ({
+//         ...prev,
+//         error:
+//           error instanceof Error
+//             ? error.message
+//             : '알 수 없는 오류가 발생했습니다.',
+//       }));
+//       isConnecting.current = false;
+//       throw error;
+//     }
+//   }, [chatRoomId]);
+
+//   // 메시지 전송 함수 (서버로 메시지를 보내는 역할)
+//   const sendMessage = async (content: string, file?: File) => {
+//     if (!chatState.isConnected) {
+//       console.error('연결이 되어있지 않습니다.');
+//       return;
+//     }
+
+//     let imgUrl: string | undefined;
+//     // 파일 업로드 처리
+//     if (file) {
+//       const formData = new FormData();
+//       formData.append('file', file);
+
+//       try {
+//         const response = await axios.post('/photo', formData, {
+//           headers: {
+//             // Authorization: 'Bearer' + token.current,
+//             'Content-Type': 'multipart/form-data',
+//           },
+//         });
+
+//         imgUrl = response.data;
+//         // 응답 상태 확인
+//       } catch (error) {
+//         console.error('File upload failed:', error);
+//         throw error; // 에러를 상위로 전파
+//       }
+//     }
+
+//     if (content || imgUrl) {
+//       const messagePayload = {
+//         senderId: userId,
+//         content,
+//       };
+
+//       try {
+//         stompClient.current?.publish({
+//           destination: `/app/chat/${chatRoomId}/send-messages`,
+//           body: JSON.stringify(messagePayload),
+//         });
+//         console.log('Message sent:', messagePayload);
+//       } catch (error) {
+//         console.error('WebSocket 메시지 전송에 실패했습니다:', error);
+//         throw error;
+//       }
+//     }
+//   };
+
+//   useEffect(() => {
+//     console.log('useEffect 트리거', {
+//       chatRoomId,
+//       isConnected: stompClient.current?.connected,
+//       hasNextPage,
+//       isFetchingNextPage,
+//     });
+
+//     const initChat = async () => {
+//       try {
+//         console.log('initChat 시작');
+
+//         // 연결 상태 명시적 확인
+//         if (!stompClient.current?.connected) {
+//           console.log('연결 시도');
+//           await connect();
+//         }
+
+//         // 페이지 로드 조건 명시적 확인
+//         // if (!isFetchingNextPage && hasNextPage) {
+//         //   console.log('이전 메시지 로드 시도');
+//         //   await fetchNextPage();
+//         // }
+//       } catch (error) {
+//         console.error('초기화 중 오류:', error);
+//       }
+//     };
+
+//     initChat();
+//   }, [chatRoomId, connect, fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+//   return {
+//     messages: messagesWithoutDuplicates,
+//     chatState,
+//     sendMessage,
+//     connect,
+//     hasNextPage,
+//     fetchNextPage,
+//     isFetchingNextPage,
+//   };
+// };
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 import axios from 'axios';
@@ -24,153 +398,121 @@ interface ChatState {
   error: string | null;
 }
 
-const fetchChatMessages = async ({
-  pageParam,
-  chatRoomId,
-  signal,
-}: {
-  pageParam: number;
-  chatRoomId: string;
-  signal: AbortSignal;
-}): Promise<{
-  messages: ChatMessage[];
-  page: number;
-  hasNextPage: boolean;
-}> => {
-  try {
-    const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/chat/${chatRoomId}/messages`,
-      {
-        params: { page: pageParam },
-        signal,
-      },
-    );
-    const { content, pageable, last } = response.data;
-
-    const hasMorePages = pageParam === 0 ? false : !last;
-    return {
-      messages: content.map((msg: ChatMessage) => ({
-        ...msg,
-        timestamp: msg.createdAt, // createdAt 필드를 timestamp로 매핑
-      })),
-      page: pageable.pageNumber,
-      hasNextPage: hasMorePages, // last 필드를 hasNextPage로 사용
-    };
-  } catch (error) {
-    console.error('이전 메시지를 로드하는 데 실패했습니다.', error);
-
-    return {
-      messages: [], // 빈 배열 반환
-      page: pageParam, // 현재 페이지 반환
-      hasNextPage: false, // 더 이상 페이지가 없다고 표시
-    };
-  }
-};
+const MESSAGES_QUERY_KEY = 'chatMessages';
 
 export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
-  const {
-    data: fetchedData,
-    hasNextPage,
-    fetchNextPage,
-    isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ['chatMessages', chatRoomId], // queryKey를 객체 형태로 제공
-    queryFn: async ({
-      pageParam = 0,
-      signal,
-    }: {
-      pageParam: number;
-      signal: AbortSignal;
-    }) => fetchChatMessages({ pageParam, chatRoomId, signal }),
-    getNextPageParam: (lastPage: any, allPages: any) =>
-      // lastPage.hasNextPage ? lastPage.page + 1 : undefined,
-      {
-        if (allPages.length === 1 && lastPage.hasNextPage) {
-          return 1;
-        }
-
-        // 더 이상 로드할 페이지가 없으면 undefined 반환
-        return lastPage.hasNextPage ? lastPage.page + 1 : undefined;
-      },
-
-    initialPageParam: 0,
-    staleTime: Infinity,
-    gcTime: 1000 * 60 * 60,
-    maxPages: 1,
-    enabled: true, // 초기 자동 로드 방지
-  });
-
-  console.log('isFetchingNextPage: ', isFetchingNextPage);
-
-  const loadInitialMessages = useCallback(async () => {
-    try {
-      await fetchNextPage();
-    } catch (error) {
-      console.error('Initial messages load failed:', error);
-    }
-  }, [fetchNextPage]);
-
-  useEffect(() => {
-    // 초기 메시지 로드
-    loadInitialMessages();
-  }, [loadInitialMessages]);
-
-  useEffect(() => {
-    if (fetchedData) {
-      const allMessages = fetchedData.pages.flatMap(page => page.messages);
-      setMessages(prevMessages => {
-        // 중복 제거 및 정렬
-        const uniqueMessages = Array.from(
-          new Map(
-            [...prevMessages, ...allMessages].map(m => [m.id, m]),
-          ).values(),
-        ).sort(
-          (a, b) =>
-            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-        );
-
-        console.log('Updated messages:', uniqueMessages);
-        return uniqueMessages;
-      });
-    }
-  }, [fetchedData]);
-
-  const stompClient = useRef<Client | null>(null); // stompClient는 STOMP 클라이언트를 생성한 후, WebSocket 연결을 관리
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const queryClient = useQueryClient();
+  const stompClient = useRef<Client | null>(null);
   const [chatState, setChatState] = useState<ChatState>({
-    isConnected: false, // 현재 연결 상태
-    error: null, // 에러 발생 시 에러 정보 저장
+    isConnected: false,
+    error: null,
   });
-
   const isConnecting = useRef(false);
 
-  // const messagesWithoutDuplicates = useMemo(() => {
-  //   // 중복 제거 및 정렬 로직
-  //   return Array.from(new Map(messages.map(m => [m.id, m])).values()).sort(
-  //     (a, b) =>
-  //       new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-  //   );
-  // }, [messages]);
-  const messagesWithoutDuplicates = useMemo(() => {
-    return Array.from(new Map(messages.map(m => [m.id, m])).values()).sort(
-      (a, b) =>
-        // 오래된 메시지가 앞으로 오도록 역순 정렬
-        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-    );
-  }, [messages]);
+  // 메시지 쿼리 키 생성 함수
+  const getMessagesQueryKey = useCallback(
+    () => [MESSAGES_QUERY_KEY, chatRoomId],
+    [chatRoomId],
+  );
 
-  const connect = useCallback(async () => {
-    console.log('connect 함수 호출됨', {
-      time: new Date().toISOString(),
-      stompClientExists: !!stompClient.current,
-      chatRoomId,
-    });
+  // 메시지 가져오기 함수
+  const fetchMessages = async ({
+    pageParam = 0,
+    signal,
+  }: {
+    pageParam: number;
+    signal: AbortSignal;
+  }) => {
+    try {
+      const response = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/chat/${chatRoomId}/messages`,
+        {
+          params: { page: pageParam },
+          signal,
+        },
+      );
 
-    if (isConnecting.current || stompClient.current?.connected) {
-      console.log('연결 중복 방지 조건 확인', {
-        isConnecting: isConnecting.current,
-        isAlreadyConnected: stompClient.current?.connected,
+      const { content, pageable, last } = response.data;
+      const hasMorePages = pageParam === 0 ? true : !last;
+
+      return {
+        messages: content.map((msg: ChatMessage) => ({
+          ...msg,
+          timestamp: msg.createdAt,
+        })),
+        page: pageable.pageNumber,
+        hasNextPage: hasMorePages,
+      };
+    } catch (error) {
+      console.error('메시지 로드 실패:', error);
+      throw error;
+    }
+  };
+
+  // React Query infinity query 설정
+  const {
+    data: messagesData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: getMessagesQueryKey(),
+    queryFn: fetchMessages,
+    getNextPageParam: lastPage =>
+      lastPage.hasNextPage ? lastPage.page + 1 : undefined,
+    initialPageParam: 0,
+    staleTime: 0,
+    gcTime: 1000 * 60 * 5, // 5분
+  });
+
+  // 새 메시지 추가 함수
+  const addNewMessage = useCallback(
+    (newMessage: ChatMessage) => {
+      queryClient.setQueryData(getMessagesQueryKey(), (oldData: any) => {
+        if (!oldData) {
+          return {
+            pages: [{ messages: [newMessage] }],
+            pageParams: [0],
+          };
+        }
+
+        // 첫 번째 페이지에 새 메시지 추가
+        const newPages = oldData.pages.map((page: any, index: number) => {
+          if (index === oldData.pages.length - 1) {
+            return {
+              ...page,
+              messages: [...page.messages, newMessage],
+            };
+          }
+          return page;
+        });
+
+        return {
+          ...oldData,
+          pages: newPages,
+        };
       });
+    },
+    [queryClient, getMessagesQueryKey],
+  );
+
+  // 연결 해제 함수
+  const disconnect = useCallback(() => {
+    if (stompClient.current?.connected) {
+      stompClient.current.deactivate();
+      stompClient.current = null;
+      setChatState(prev => ({ ...prev, isConnected: false }));
+      console.log('WebSocket 연결 해제됨');
+
+      // 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: getMessagesQueryKey() });
+    }
+  }, [queryClient, getMessagesQueryKey]);
+
+  // 연결 함수
+  const connect = useCallback(async () => {
+    if (isConnecting.current || stompClient.current?.connected) {
       return;
     }
 
@@ -181,59 +523,20 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
       const socket = new SockJS(
         `${process.env.NEXT_PUBLIC_CHAT_SOCKET_URL}/ws` as string,
       );
-      console.log('SockJS 생성 완료', {
-        socketState: socket.readyState, // 0: connecting, 1: open, 2: closing, 3: closed
-      });
 
       await new Promise<void>((resolve, reject) => {
         const client = new Client({
-          webSocketFactory: () => socket, // SockJS를 사용하여 WebSocket 연결 생성
-          reconnectDelay: 5000, // SockJS를 사용하여 WebSocket 연결 생성
-          heartbeatIncoming: 4000, // SockJS를 사용하여 WebSocket 연결 생성
-          heartbeatOutgoing: 4000, // SockJS를 사용하여 WebSocket 연결 생성
-
-          debug: msg => {
-            console.log('STOMP Debug:', msg);
-          },
+          webSocketFactory: () => socket,
+          reconnectDelay: 5000,
+          heartbeatIncoming: 4000,
+          heartbeatOutgoing: 4000,
 
           onConnect: () => {
-            console.log('onConnect 실행', {
-              time: new Date().toISOString(),
-              socketState: socket.readyState,
-              clientConnected: client.connected,
+            client.subscribe(`/topic/chat/${chatRoomId}`, messageOutput => {
+              const newMessage = JSON.parse(messageOutput.body) as ChatMessage;
+              newMessage.timestamp = newMessage.createdAt;
+              addNewMessage(newMessage);
             });
-
-            try {
-              client.subscribe(`/topic/chat/${chatRoomId}`, messageOutput => {
-                console.log('WebSocket 메시지 수신:', messageOutput.body);
-
-                const newMessage = JSON.parse(
-                  messageOutput.body,
-                ) as ChatMessage;
-
-                // timestamp 필드 보장
-                newMessage.timestamp = newMessage.createdAt;
-
-                setMessages(prevMessages => {
-                  // 중복 체크 로직 유지
-                  const isDuplicate = prevMessages.some(
-                    msg => msg.id === newMessage.id,
-                  );
-                  if (isDuplicate) return prevMessages;
-
-                  const updatedMessages = [...prevMessages, newMessage].sort(
-                    (a, b) =>
-                      new Date(a.timestamp).getTime() -
-                      new Date(b.timestamp).getTime(),
-                  );
-
-                  console.log('메시지 상태 업데이트:', updatedMessages);
-                  return updatedMessages;
-                });
-              });
-            } catch (error) {
-              console.error('구독 실패:', error);
-            }
 
             setChatState({
               isConnected: true,
@@ -244,17 +547,12 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
           },
 
           onDisconnect: () => {
-            console.log('WebSocket 연결 해제됨');
             setChatState(prev => ({ ...prev, isConnected: false }));
+            // 연결이 끊겼을 때 캐시 무효화
+            queryClient.invalidateQueries({ queryKey: getMessagesQueryKey() });
           },
 
           onStompError: frame => {
-            console.error('STOMP 에러 발생:', {
-              headers: frame.headers,
-              body: frame.body,
-              command: frame.command,
-            });
-
             reject(
               new Error(frame.headers.message || '연결 오류가 발생했습니다.'),
             );
@@ -262,16 +560,9 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
         });
 
         stompClient.current = client;
-        console.log('client.activate() 호출 전');
-        client.activate(); // 웹소켓 연결이 시작됨 -> 연결이 성공하면 onConnect 콜백이 실행됨
-        console.log('client.activate() 호출 후');
+        client.activate();
       });
     } catch (error) {
-      console.log('연결 실패', {
-        error,
-        time: new Date().toISOString(),
-      });
-
       setChatState(prev => ({
         ...prev,
         error:
@@ -282,78 +573,26 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
       isConnecting.current = false;
       throw error;
     }
-  }, [chatRoomId]);
+  }, [chatRoomId, addNewMessage, queryClient, getMessagesQueryKey]);
 
-  // 이전 메시지 로드 함수
-  // const loadPreviousMessages = useCallback(async () => {
-  //   const size = 20;
-  //   try {
-  //     const response = await axios.get(
-  //       `${process.env.NEXT_PUBLIC_CHAT_SOCKET_URL}/chat/${chatRoomId}/messages`,
-  //       {
-  //         params: { page, size },
-  //       },
-  //     );
-  //     const previousMessages: ChatMessage[] = response.data.messages.map(
-  //       (msg: any) => ({
-  //         messageId: msg.id,
-  //         chatRoomId: msg.chatRoomId,
-  //         content: msg.content,
-  //         timestamp: new Date(msg.createdAt).toLocaleTimeString('ko-KR', {
-  //           hour: '2-digit',
-  //           minute: '2-digit',
-  //         }),
-  //         user: {
-  //           id: msg.user.id,
-  //           email: msg.userEmail,
-  //           profileImageUrl: msg.userProfileImageUrl,
-  //           isActive: msg.isActive,
-  //           createdAt: msg.createdAt,
-  //           updatedAt: msg.updatedAt,
-  //           nickname: msg.nickname || '알 수 없는 사용자',
-  //         },
-  //       }),
-  //     );
-  //     console.log('Previous messages:', previousMessages);
-  //     setMessages(prev => [...previousMessages, ...prev]);
-  //     // setMessages(previousMessages);
-
-  //     if (previousMessages.length < size) {
-  //       setHasMore(false);
-  //     }
-
-  //     setPage(prevPage => prevPage + 1);
-  //   } catch (error) {
-  //     console.error('이전 메시지 로드 실패:', error);
-  //   }
-  // }, [chatRoomId, page, hasMore]);
-
-  // 메시지 전송 함수 (서버로 메시지를 보내는 역할)
+  // 메시지 전송 함수
   const sendMessage = async (content: string, file?: File) => {
     if (!chatState.isConnected) {
-      console.error('연결이 되어있지 않습니다.');
-      return;
+      await connect();
     }
 
     let imgUrl: string | undefined;
-    // 파일 업로드 처리
     if (file) {
       const formData = new FormData();
       formData.append('file', file);
-
       try {
         const response = await axios.post('/photo', formData, {
-          headers: {
-            // Authorization: 'Bearer' + token.current,
-            'Content-Type': 'multipart/form-data',
-          },
+          headers: { 'Content-Type': 'multipart/form-data' },
         });
-
         imgUrl = response.data;
-        // 응답 상태 확인
       } catch (error) {
-        console.error('File upload failed:', error);
-        throw error; // 에러를 상위로 전파
+        console.error('파일 업로드 실패:', error);
+        throw error;
       }
     }
 
@@ -361,6 +600,7 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
       const messagePayload = {
         senderId: userId,
         content,
+        imgUrl,
       };
 
       try {
@@ -368,52 +608,39 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
           destination: `/app/chat/${chatRoomId}/send-messages`,
           body: JSON.stringify(messagePayload),
         });
-        console.log('Message sent:', messagePayload);
       } catch (error) {
-        console.error('WebSocket 메시지 전송에 실패했습니다:', error);
+        console.error('메시지 전송 실패:', error);
         throw error;
       }
     }
   };
 
+  // 컴포넌트 마운트/언마운트 처리
   useEffect(() => {
-    console.log('useEffect 트리거', {
-      chatRoomId,
-      isConnected: stompClient.current?.connected,
-      hasNextPage,
-      isFetchingNextPage,
-    });
+    connect();
 
-    const initChat = async () => {
-      try {
-        console.log('initChat 시작');
-
-        // 연결 상태 명시적 확인
-        if (!stompClient.current?.connected) {
-          console.log('연결 시도');
-          await connect();
-        }
-
-        // 페이지 로드 조건 명시적 확인
-        // if (!isFetchingNextPage && hasNextPage) {
-        //   console.log('이전 메시지 로드 시도');
-        //   await fetchNextPage();
-        // }
-      } catch (error) {
-        console.error('초기화 중 오류:', error);
-      }
+    return () => {
+      disconnect();
     };
+  }, [connect, disconnect]);
 
-    initChat();
-  }, [chatRoomId, connect, fetchNextPage, hasNextPage, isFetchingNextPage]);
+  // 메시지 정렬 및 중복 제거
+  const messages = messagesData?.pages.flatMap(page => page.messages) ?? [];
+  const uniqueMessages = Array.from(
+    new Map(messages.map(m => [m.id, m])).values(),
+  ).sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  );
 
   return {
-    messages: messagesWithoutDuplicates,
+    messages: uniqueMessages,
     chatState,
     sendMessage,
     connect,
+    disconnect,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
+    refetch,
   };
 };

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -7,6 +7,7 @@ export interface User {
   createdAt?: string;
   updatedAt?: string;
   nickname: string;
+  signinType?: string | null;
 }
 
 // 정보공유 게시글

--- a/src/utils/authHelper.ts
+++ b/src/utils/authHelper.ts
@@ -39,8 +39,9 @@ export const handleUserInfo = async (
       throw new Error('사용자 정보 조회에 실패했습니다.');
     }
 
-    const { id, nickname, email, profileImageUrl } = userResponse.data; // 필요한 필드만 추출
-    const userInfo = { id, nickname, email, profileImageUrl };
+    const { id, nickname, email, profileImageUrl, signinType } =
+      userResponse.data; // 필요한 필드만 추출
+    const userInfo = { id, nickname, email, profileImageUrl, signinType };
 
     // 3. 쿠키 설정
     const currentTime = Math.trunc(Date.now() / 1000);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 회원탈퇴 & 비밀번호 변경
    - 백엔드에 password가 제대로 전달되지 않음
    - 회원탈퇴 시 Next.js api route 코드에서 패스워드 무조건 백엔드로 전달
- 채팅방
    - 기본적인 채팅방 디자인
    - 채팅방 나간 후 재입장 시 이전에 주고받은 실시간 메시지가 로드되지 않음
- 내가 속한 스터디
    - 스터디장 배지 가독성이 떨어지고 창 크기에 따라 깨지는 현상 발생
    
**TO-BE**
- 회원탈퇴 & 비밀번호 변경
    - 백엔드에 password가 제대로 전달됨
    - 컨펌창에 입력한 비밀번호 상태 업데이트 됨
    - 회원탈퇴 시 소셜로그인이 아닌 경우에만 Next.js api route 코드에서 password 백엔드로 전달
    - 회원탈퇴 시 미들웨어 사용하지 않고 직접 토큰을 가져와 요청헤더로 전달
- 채팅방
    - daisyUI, tailwind css 를 활용하여 채팅방 디자인 수정
    - 반응형 디자인 추가
    - 채팅방 나간 후 재입장 시 이전에 주고받은 실시간 메시지가 로드됨 (`useQueryClient` 활용)
    - 무한 스크롤 적용 에러 해결중
- 내가 속한 스터디
    - `react-icons` 활용하여 스터디장 배지 눈에 띄게 디자인 수정
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] 비밀번호 변경, 회원탈퇴 백엔드 테스트
- [X] 채팅방 재입장시 실시간 메시지 로드 테스트
