### PR TITLE
fix: 정보공유, Q&A 카드 컴포넌트 통합 및 디자인 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,10 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['devonoffbucket.s3.ap-northeast-2.amazonaws.com'], // 외부 이미지 도메인 추가
+    domains: [
+      'devonoffbucket.s3.ap-northeast-2.amazonaws.com',
+      'swany-bucket.s3.ap-northeast-2.amazonaws.com',
+    ], // 외부 이미지 도메인 추가
   },
   async headers() {
     return [

--- a/src/app/community/components/InfoList.tsx
+++ b/src/app/community/components/InfoList.tsx
@@ -7,6 +7,7 @@ import { InfoPost, PostResponse } from '@/types/post';
 import { PostList } from '@/app/community/components/PostList';
 import { useAuthStore } from '@/store/authStore';
 import SearchForm from '@/app/community/components/SearchForm';
+import MyInfoPostCard from '@/app/mypage/components/MyInfoPostCard';
 
 export default function InfoList() {
   const router = useRouter();
@@ -60,33 +61,7 @@ export default function InfoList() {
         onPageChange={handlePageChange}
         onWrite={handleWrite}
         isSignedIn={isSignedIn}
-        renderPostCard={post => (
-          <div
-            key={post.id}
-            className="card bg-base-100 shadow-xl cursor-pointer hover:shadow-2xl transition-shadow w-full min-w-[320px] max-w-[320px]"
-            onClick={() => router.push(`/community/info/${post.id}`)}
-          >
-            <figure className="px-4 pt-4">
-              <img
-                src={post.thumbnailImgUrl || '/default-info-thumbnail.png'}
-                alt={post.title}
-                className="rounded-xl h-48 w-full object-cover"
-              />
-            </figure>
-            <div className="card-body">
-              <h2 className="card-title">{post.title}</h2>
-              <p className="text-base-content/70">
-                {post.description?.slice(0, 100) || '내용이 없습니다.'}
-                {post.description && post.description.length > 100 ? '...' : ''}
-              </p>
-              <div className="flex justify-between items-center mt-4">
-                <div className="text-sm text-base-content/60">
-                  작성자: {post.user.nickname}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        renderPostCard={post => <MyInfoPostCard key={post.id} post={post} />}
       />
     </>
   );

--- a/src/app/community/components/QnAList.tsx
+++ b/src/app/community/components/QnAList.tsx
@@ -7,6 +7,7 @@ import { QnAPost, PostResponse } from '@/types/post';
 import { PostList } from '@/app/community/components/PostList';
 import { useAuthStore } from '@/store/authStore';
 import SearchForm from '@/app/community/components/SearchForm';
+import MyQnAPostCard from '@/app/mypage/components/MyQnAPostCard';
 
 export default function QnAList() {
   const router = useRouter();
@@ -60,33 +61,7 @@ export default function QnAList() {
         onPageChange={handlePageChange}
         onWrite={handleWrite}
         isSignedIn={isSignedIn}
-        renderPostCard={post => (
-          <div
-            key={post.id}
-            className="card bg-base-100 shadow-xl cursor-pointer hover:shadow-2xl transition-shadow w-full min-w-[320px] max-w-[320px]"
-            onClick={() => router.push(`/community/qna/${post.id}`)}
-          >
-            <figure className="px-4 pt-4">
-              <img
-                src={post.thumbnailImgUrl || '/default-qna-thumbnail.png'}
-                alt={post.title}
-                className="rounded-xl h-48 w-full object-cover"
-              />
-            </figure>
-            <div className="card-body">
-              <h2 className="card-title">{post.title}</h2>
-              <p className="text-base-content/70">
-                {post.content?.slice(0, 100) || '내용이 없습니다.'}
-                {post.content && post.content.length > 100 ? '...' : ''}
-              </p>
-              <div className="flex justify-between items-center mt-4">
-                <div className="text-sm text-base-content/60">
-                  작성자: {post.user.nickname}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        renderPostCard={post => <MyQnAPostCard key={post.id} post={post} />}
       />
     </div>
   );

--- a/src/app/mypage/components/MyInfoPostCard.tsx
+++ b/src/app/mypage/components/MyInfoPostCard.tsx
@@ -34,7 +34,7 @@ const MyInfoPostCard = ({ post }: MyPostCardProps) => {
         <h2 className="card-title text-lg">{post.title}</h2>
         <div className="space-y-2 text-sm">
           <div className="flex justify-between">
-            <span>정보 공유</span>
+            <span>작성자: {post.user.nickname}</span>
           </div>
           <div className="flex justify-between">
             <span>내용:</span>
@@ -49,9 +49,10 @@ const MyInfoPostCard = ({ post }: MyPostCardProps) => {
             <span>{formatDate(post.updatedAt)}</span>
           </div>
         </div>
-      </div>
-      <div className="card-actions justify-end mt-4">
-        <button className="btn btn-primary btn-sm">상세보기</button>
+
+        <div className="text-right mt-2">
+          <span className="text-sm hover:opacity-70">상세보기 →</span>
+        </div>
       </div>
     </div>
   );

--- a/src/app/mypage/components/MyQnAPostCard.tsx
+++ b/src/app/mypage/components/MyQnAPostCard.tsx
@@ -34,7 +34,7 @@ const MyQnAPostCard = ({ post }: MyPostCardProps) => {
         <h2 className="card-title text-lg">{post.title}</h2>
         <div className="space-y-2 text-sm">
           <div className="flex justify-between">
-            <span>정보 공유</span>
+            <span>작성자: {post.user.nickname}</span>
           </div>
           <div className="flex justify-between">
             <span>내용:</span>
@@ -49,9 +49,9 @@ const MyQnAPostCard = ({ post }: MyPostCardProps) => {
             <span>{formatDate(post.updatedAt)}</span>
           </div>
         </div>
-      </div>
-      <div className="card-actions justify-end mt-4">
-        <button className="btn btn-primary btn-sm">상세보기</button>
+        <div className="text-right mt-2">
+          <span className="text-sm hover:opacity-70">상세보기 →</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**

- 정보공유, Q&A의 카드 컴포넌트가 마이페이지, 게시판 페이지에서 각각 구현됨

**TO-BE**

- 정보공유, Q&A의 카드 컴포넌트를 하나의 컴포넌트로 통일해 사용

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [x] 빌드 테스트
- [x] API 테스트
