### PR TITLE
fix: 표기 오류, 스터디룸 나가기 문제 해결

### DIFF
--- a/src/app/community/ranking/page.tsx
+++ b/src/app/community/ranking/page.tsx
@@ -54,7 +54,7 @@ export default function RankingPage() {
               <th className="w-1/6">순위</th>
               <th className="w-2/6">스터디명</th>
               <th className="w-2/6">총 공부시간</th>
-              <th className="w-1/6">달성률</th>
+              <th className="w-1/6">상위</th>
             </tr>
           </thead>
           <tbody>
@@ -75,7 +75,7 @@ export default function RankingPage() {
                       value={rank.percent}
                       max="100"
                     ></progress>
-                    <span className="text-sm">{rank.percent}%</span>
+                    <span className="text-sm">{rank.percent.toFixed(2)}%</span>
                   </div>
                 </td>
               </tr>

--- a/src/app/studyroom/components/VideoRoomComponents.tsx
+++ b/src/app/studyroom/components/VideoRoomComponents.tsx
@@ -521,11 +521,11 @@ export default function VideoRoomComponent() {
       }
 
       // 4. 페이지 이동
-      router.push('/mypage');
+      router.push(`/`);
     } catch (error) {
       console.error('연결 종료 중 오류 발생:', error);
-      // 에러가 발생해도 마이페이지로 이동
-      router.push('/mypage');
+      // 에러가 발생해도 페이지 이동
+      router.push(`/`);
     }
   };
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
상위 스터디 (%) 가 달성률로 표기됨
상위 스터디의 백분율이 너무 길게 표기됨
스터디 종료 및 나가기 버튼 클릭 시 404 페이지로 이동
**TO-BE**
달성률 -> 상위 로 변경
백분율을 toFixed로 소수점 둘째 자리까지 표기
스터디 종료 및 나가기 버튼 클릭 시 사이트 홈으로 이동

### 테스트
- [x] 빌드 테스트
- [x] API 테스트