### PR TITLE
design: 회원정보 좌우 여백 줄이기 / 탭에서 카드끼리 겹치는 문제 해결

### DIFF
--- a/src/app/mypage/components/MyStudyView.tsx
+++ b/src/app/mypage/components/MyStudyView.tsx
@@ -153,7 +153,7 @@ const MyStudyView = () => {
       return <p>{currentTab.emptyMessage}</p>;
 
     return (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
         {currentTab.data.map((post: any) => (
           <div className="flex justify-center" key={post.id}>
             <currentTab.component post={post} />

--- a/src/app/mypage/components/UserInfoView.tsx
+++ b/src/app/mypage/components/UserInfoView.tsx
@@ -420,7 +420,7 @@ const UserInfoView = () => {
   };
 
   return (
-    <div className="flex flex-col md:flex-row gap-8 p-8 max-w-4xl mx-auto">
+    <div className="flex flex-col md:flex-row gap-8 p-8 max-w-5xl mx-auto">
       <div className="flex flex-col items-center w-full md:w-1/3 md:border-r md:pr-4">
         <div className="relative">
           <Image
@@ -511,7 +511,7 @@ const UserInfoView = () => {
               className="btn btn-accent w-full md:w-auto"
               onClick={handleWithdrawalButtonClick}
             >
-              회원 탈퇴
+              회원 탈퇴햣
             </button>
           </div>
         </div>


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 마이페이지
  - 모바일과 태블릿 환경에서 게시글 카드 겹침
  - 회원정보 컴포넌트의 좌우 여백이 탭의 좌우여백과 달라 통일감이 없음
 
**TO-BE**
- 마이페이지
  - 모바일과 태블릿 환경에서 한 줄에 한 개씩 보이도록 수정하여 겹치는 문제 해결
  - 회원정보 컴포넌트의 좌우 여백이 탭의 좌우여백과 비슷하도록 변경
