### PR TITLE
design: 맥 환경에서 카드 겹침 문제 해결, 배경 수정, 스터디 게시판 탭 디자인 되돌림

### DIFF
--- a/src/app/community/components/PostList.tsx
+++ b/src/app/community/components/PostList.tsx
@@ -47,7 +47,7 @@ export function PostList<T extends InfoPost | QnAPost>({
       {/* 필터 영역 */}
       {showFilters && filterComponent}
 
-      <div className="bg-base-100 shadow-xl rounded-lg p-6">
+      <div className="bg-base-100 p-2">
         {isLoading ? (
           <div className="flex justify-center items-center h-60">
             <span className="loading loading-spinner loading-lg"></span>

--- a/src/app/community/study/components/HybridStudyList.tsx
+++ b/src/app/community/study/components/HybridStudyList.tsx
@@ -143,7 +143,7 @@ export default function HybridStudyList() {
   };
 
   return (
-    <div className="space-y-4 max-w-6xl mx-auto p-4">
+    <div className="space-y-4 max-w-6xl mx-auto">
       <SearchForm
         initialKeyword={searchParams.get('title') || ''}
         placeholder="스터디 제목을 검색하세요"
@@ -172,7 +172,7 @@ export default function HybridStudyList() {
           userLocation={userLocation}
         />
       </div>
-      <div className="bg-base-100 shadow-xl rounded-lg p-6">
+      <div className="bg-base-100 p-2">
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-y-6 gap-x-0">
           {isLoading ? (
             <div>로딩 중...</div>

--- a/src/app/community/study/components/OnlineStudyList.tsx
+++ b/src/app/community/study/components/OnlineStudyList.tsx
@@ -110,7 +110,7 @@ export default function OnlineStudyList() {
   };
 
   return (
-    <div className="space-y-4 max-w-6xl mx-auto p-4">
+    <div className="space-y-4 max-w-6xl mx-auto">
       <SearchForm
         initialKeyword={searchParams.get('title') || ''}
         placeholder="스터디 제목을 검색하세요"
@@ -123,7 +123,7 @@ export default function OnlineStudyList() {
         selectedDays={selectedDays}
         onFilterChange={handleFilterChange}
       />
-      <div className="bg-base-100 shadow-xl rounded-lg p-6">
+      <div className="bg-base-100 p-2">
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-y-6 gap-x-0">
           {isLoading ? (
             <div>로딩 중...</div>

--- a/src/app/community/study/components/StudyList.tsx
+++ b/src/app/community/study/components/StudyList.tsx
@@ -59,24 +59,16 @@ export default function StudyList() {
         )}
       </div>
 
-      <div role="tablist" className="tabs tabs-lifted tabs-lg hover:tab-lifted">
+      <div className="tabs tabs-boxed">
         <button
-          onClick={() => handleTypeChange('ONLINE')}
-          className={`tab tab-lg text-base hover:font-bold hover:text-lg hover:text-black hover:shadow-lg ${
-            studyType === 'ONLINE'
-              ? 'tab-active text-black font-bold text-lg'
-              : 'bg-transparent text-gray-500'
-          }`}
+          className={`tab ${studyType === 'ONLINE' ? 'bg-black text-white border-transparent' : 'text-gray-700 hover:text-white hover:bg-gray-500'}`}
+          onClick={() => setStudyType('ONLINE')}
         >
           {MEETING_TYPE.ONLINE}
         </button>
         <button
-          onClick={() => handleTypeChange('HYBRID')}
-          className={`tab tab-lg text-base hover:font-bold hover:text-lg hover:text-black hover:shadow-lg ${
-            studyType === 'HYBRID'
-              ? 'tab-active text-black font-bold text-lg'
-              : 'bg-transparent text-gray-500'
-          }`}
+          className={`tab ${studyType === 'HYBRID' ? 'bg-black text-white border-transparent' : 'text-gray-700 hover:text-white hover:bg-gray-500'}`}
+          onClick={() => setStudyType('HYBRID')}
         >
           {MEETING_TYPE.HYBRID}
         </button>


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 맥 환경에서 게시글 카드들이 미세하게 겹쳐보임
- 배경색 존재
- 스터디 게시판 온라인/병행 탭 마이페이지와 통일

**TO-BE**
- 맥 환경에서 게시글 카드들이 미세하게 겹쳐보이는 문제 해결
- 배경색을 없애 깔끔하도록 수정
- 스터디 게시판 온라인/병행 탭 이전 디자인으로 돌려 눈에 띄도록 수정
