### PR TITLE
design: 채팅 최대 텍스트 사용자에게 안내

### DIFF
--- a/src/app/api/auth/sign-out/route.ts
+++ b/src/app/api/auth/sign-out/route.ts
@@ -29,13 +29,13 @@ export const POST = async () => {
       } else {
         return NextResponse.json(
           { errorMessage: '액세스 토큰 재발급 실패' },
-          { status: 500 },
+          { status: 403 },
         );
       }
     } catch (error) {
       return NextResponse.json(
         { errorMessage: '액세스 토큰 재발급 실패', error },
-        { status: 500 },
+        { status: 403 },
       );
     }
   }

--- a/src/app/chat/components/MessageInput.tsx
+++ b/src/app/chat/components/MessageInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, FormEvent } from 'react';
 import { FiSend } from 'react-icons/fi';
 
 interface MessageInputProps {
@@ -8,20 +8,46 @@ interface MessageInputProps {
 const MessageInput = ({ onSendMessage }: MessageInputProps) => {
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [byteExceeded, setByteExceeded] = useState(false);
+  const [exceedingCharacters, setExceedingCharacters] = useState(0);
+  const [isComposing, setIsComposing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
 
+  // 한글 문자와 기타 문자의 바이트 크기를 계산하는 함수
+  const calculateBytes = (str: string) => {
+    let byteLength = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charAt(i);
+      // 한글은 2바이트로 계산, 나머지 문자는 1바이트로 계산
+      if (/[\u3131-\uD79D]/.test(char)) {
+        byteLength += 2; // 한글 문자
+      } else {
+        byteLength += 1; // 영어 및 특수 문자
+      }
+    }
+    return byteLength;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!content.trim() && !fileInputRef.current?.files?.[0]) return;
+    const trimmedContent = content.trim();
+    if (!trimmedContent && !fileInputRef.current?.files?.[0]) return;
+
+    // 750 바이트 초과시 전송 방지
+    if (byteExceeded) {
+      return;
+    }
 
     setIsLoading(true);
+
     try {
-      await onSendMessage(content, fileInputRef.current?.files?.[0]);
+      await onSendMessage(trimmedContent, fileInputRef.current?.files?.[0]);
       setContent('');
+      setByteExceeded(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
     } catch (error) {
-      console.error('Failed to send message:', error);
+      console.error('메시지 전송에 실패했습니다.', error);
     } finally {
       setIsLoading(false);
 
@@ -29,6 +55,38 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
         messageInputRef.current.focus();
       }
     }
+  };
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newContent = e.target.value;
+    const byteLength = calculateBytes(newContent);
+
+    if (byteLength <= 750) {
+      setContent(newContent);
+      setByteExceeded(false);
+      setExceedingCharacters(0);
+    } else {
+      setContent(newContent.slice(0, newContent.length - 1)); // 마지막 문자 제거하여 750바이트 이하로 유지
+      setByteExceeded(true);
+      setExceedingCharacters(Math.ceil((byteLength - 750) / 2)); // 초과된 바이트 수 계산
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
+      e.preventDefault();
+
+      if (!isLoading) {
+        const fakeEvent = { preventDefault: () => {} } as React.FormEvent;
+        handleSubmit(fakeEvent);
+      }
+    }
+  };
+
+  const handleTextareaInput = (e: FormEvent<HTMLTextAreaElement>) => {
+    const target = e.target as HTMLTextAreaElement;
+    target.style.height = 'auto';
+    target.style.height = `${target.scrollHeight}px`;
   };
 
   return (
@@ -56,18 +114,11 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
         <textarea
           ref={messageInputRef}
           value={content}
-          onChange={e => setContent(e.target.value)}
-          onKeyDown={e => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              handleSubmit(e);
-            }
-          }}
-          onInput={e => {
-            const target = e.target as HTMLTextAreaElement;
-            target.style.height = 'auto'; // 높이를 초기화
-            target.style.height = `${target.scrollHeight}px`; // 내용에 따라 높이 조정
-          }}
+          onChange={handleContentChange}
+          onKeyDown={handleKeyDown}
+          onInput={handleTextareaInput}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
           placeholder="메시지를 입력하세요..."
           className="flex-1 textarea textarea-bordered w-full bg-white text-base sm:text-lg max-h-60 overflow-y-auto"
           disabled={isLoading}
@@ -76,12 +127,17 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
         <button
           type="submit"
           className="btn btn-base bg-green-400 text-base hover:bg-green-500 text-white rounded-full flex items-center gap-2 px-8 py-2"
-          disabled={isLoading}
+          disabled={isLoading || byteExceeded}
         >
           {isLoading ? '전송 중...' : '전송'}
           {!isLoading && <FiSend className="text-lg" />}
         </button>
       </div>
+      {byteExceeded && (
+        <p className="text-red-500 text-sm mt-2">
+          현재 입력하신 텍스트는 {exceedingCharacters}글자를 초과했습니다.
+        </p>
+      )}
     </form>
   );
 };

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -33,6 +33,7 @@ export interface MyStudyCardData {
   endDate: string;
   startTime: string;
   endTime: string;
+  meetingType: string;
   status: string;
   studyPostId: number;
   studyLeaderId: number;

--- a/src/hooks/useGroupChat.ts
+++ b/src/hooks/useGroupChat.ts
@@ -163,6 +163,7 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
               newMessage.timestamp = newMessage.createdAt;
               // addNewMessage(newMessage);
               // 현재 캐시된 데이터 확인
+              console.log('보낸 메시지', newMessage);
               const currentData = queryClient.getQueryData(
                 getMessagesQueryKey(),
               ) as any;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 채팅
  - 최대 텍스트 길이가 정해지지 않아 사용자가 최대로 입력해야 하는 길이를 알지 못한 채로 메시지 전송 실패
- 토큰 발급 에러
  - 500 에러로 세팅
- 내가 속한 스터디
  - meetingType 따로 정의하지 않음

**TO-BE**
- 채팅
  - 백엔드에서 최대 길이를 750바이트로 설정한 것에 맞춰 750 바이트 이상 입력 시 버튼 비활성화 & 초과된 글자 수 안내
- 토큰 발급 에러
  - 백엔드에 맞춰 403 에러로 수정
- 내가 속한 스터디
  - 응답 데이터 meetingType 추가
  - 추후, 스터디 카드에 meetingType 표시 예정
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] 750바이트까지 전송 성공하는지 테스트