### PR TITLE
design: 내가 속한 스터디 '스터디 방식' 표시 추가 및 스터디 게시판 검색 필터 초기화 버튼 디자인 수정 / feat: Axios Interceptor 활용한 api 요청 방식 기본 구현

### DIFF
--- a/src/app/community/study/components/StudyFilter.tsx
+++ b/src/app/community/study/components/StudyFilter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReadonlyURLSearchParams } from 'next/navigation';
+import { RiCloseCircleLine } from 'react-icons/ri';
 
 type FilterType = 'subjects' | 'status' | 'difficulty' | 'dayType';
 
@@ -73,7 +74,8 @@ export function StudyFilter({
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-lg font-bold">필터</h2>
         <button onClick={onReset} className="btn btn-sm btn-outline">
-          필터 초기화
+          <RiCloseCircleLine size={16} />
+          전체 해제
         </button>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -41,6 +41,11 @@ export interface MyStudyCardData {
   thumbnailImgUrl?: string;
 }
 
+const MEETING_TYPES = {
+  ONLINE: '온라인',
+  HYBRID: '병행',
+};
+
 const MyStudyCard = ({ post }: MyStudyCardProps) => {
   const router = useRouter();
   const { userInfo } = useAuthStore();
@@ -137,6 +142,11 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
               <span className="text-white text-xs font-bold">스터디장</span>
             </div>
           )}
+          <div className="absolute top-4 left-4 flex flex-col items-center space-y-1 bg-black p-2 rounded-lg shadow-md">
+            <span className="text-white text-xs font-bold">
+              {MEETING_TYPES[post.meetingType as keyof typeof MEETING_TYPES]}
+            </span>
+          </div>
         </h2>
         <div className="grid grid-cols-2 gap-2">
           <div className="badge badge-lg bg-primary/70 text-base px-4 py-3 rounded-full">

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+
+const axiosInstance = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_ROUTE_URL}`,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+axiosInstance.interceptors.request.use(
+  config => {
+    if (config.headers['Content-Type'] === 'multipart/form-data') {
+      return config;
+    }
+    return config;
+  },
+
+  error => {
+    return Promise.reject(error);
+  },
+);
+
+axiosInstance.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response && error.response.status === 401) {
+      console.error('axios interceptor 인증 에러');
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default axiosInstance;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 마이페이지 - 내가 속한 스터디
  - 내가 속한 스터디의 스터디 방식을 알려주지 않아 사용자가 구분하기 어려움
- 스터디 게시판
  - 검색 필터 초기화 버튼 구현되어 있음
- API 요청
 - api 요청 에러 처리를 클라이언트 컴포넌트에서 대부분 구현

**TO-BE**
- 마이페이지 - 내가 속한 스터디
  - 내가 속한 스터디의 스터디 방식이 온라인인지 병행인지 표시
- 스터디 게시판
  - `react-icons`를 활용하여 검색 필터 초기화 버튼 디자인 개선
- API 요청
  - `Axios Interceptor`가 요청을 가로채서 에러 처리를 해줄 수 있도록 axios.ts파일 세팅
