### PR TITLE
fix: Layout Shift 현상 해결, aria-label, placeholder등을 통한 사용자경험 개선 / feat: 채팅방 스터디장 표시 기능 구현

### DIFF
--- a/src/app/api/auth/token-reissue/route.ts
+++ b/src/app/api/auth/token-reissue/route.ts
@@ -52,6 +52,9 @@ export const POST = async (req: NextRequest) => {
         status: error.response.status,
       });
     }
-    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+    return NextResponse.json(
+      { errorMessage: '서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.' },
+      { status: 500 },
+    );
   }
 };

--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -14,9 +14,26 @@ interface ChatRoomProps {
   // studyId: string;
 }
 
+// interface Message {
+//   timestamp: string;
+//   content: string;
+//   user: {
+//     id: number;
+//     nickname: string;
+//     profileImageUrl: string;
+//   };
+// }
+
+// const ChatHeader = ({ studyName }: { studyName: string | null }) => {
+//   <>
+//     <div></div>
+//   </>;
+// };
+
 const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
   const searchParams = useSearchParams();
   const studyName = searchParams.get('studyName');
+  const studyLeaderId = Number(searchParams.get('studyLeaderId'));
 
   const { userInfo } = useAuthStore();
   const userId = userInfo?.id || 111;
@@ -226,6 +243,9 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
                 >
                   {msg.user.id !== userId && (
                     <div className="flex flex-col items-center min-w-[70px]">
+                      {msg.user.id === studyLeaderId && (
+                        <FaCrown size={20} className="text-teal-500" />
+                      )}
                       <img
                         src={
                           msg.user.profileImageUrl ||
@@ -275,7 +295,10 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
                   {msg.user.id === userId && (
                     <div className="flex flex-col items-center min-w-[70px]">
                       {/* 실제 스터디장 프로필에 표시하는 것으로 수정 예정 */}
-                      <FaCrown size={20} className="text-teal-500" />
+                      {msg.user.id === studyLeaderId && (
+                        <FaCrown size={20} className="text-teal-500" />
+                      )}
+                      {/* <FaCrown size={20} className="text-teal-500" /> */}
                       <img
                         src={
                           msg.user.profileImageUrl ||

--- a/src/app/community/study/write/components/OnlineForm.tsx
+++ b/src/app/community/study/write/components/OnlineForm.tsx
@@ -177,7 +177,7 @@ export default function OnlineForm({ initialData, isEdit }: OnlineFormProps) {
         } catch (error: any) {
           console.error('스터디 글 작성/수정 실패:', error);
           setAlertMessage(
-            error.response?.data?.message ||
+            error.response?.data?.errorMessage ||
               '스터디 글 작성/수정에 실패했습니다. 다시 시도해주세요.',
           );
           setShowAlert(true);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,11 +22,15 @@ export default async function RootLayout({
         <Providers>
           {process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' && <MSWProvider />}
           <div className="flex flex-col min-h-screen">
-            <Header />
-            <main className="flex-1 container mx-auto px-4 py-8 pt-[4rem]">
+            <div className="h-16">
+              <Header />
+            </div>
+            <main className="flex-1 container mx-auto px-4 py-8 pt-16 min-h-[calc(100vh-16rem)]">
               {children}
             </main>
-            <Footer />
+            <div className="h-48">
+              <Footer />
+            </div>
           </div>
         </Providers>
       </body>

--- a/src/app/middlewares/processRefreshToken.ts
+++ b/src/app/middlewares/processRefreshToken.ts
@@ -60,7 +60,12 @@ const processRefreshToken = async (
         status: error.response.status,
       });
     }
-    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+    return NextResponse.json(
+      {
+        errorMessage: '서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      },
+      { status: 500 },
+    );
   }
 };
 

--- a/src/app/mypage/components/MyStudyCard.tsx
+++ b/src/app/mypage/components/MyStudyCard.tsx
@@ -122,6 +122,11 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
     return true;
   };
 
+  const handleDetailButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    router.push(`/community/study/${post.studyPostId}`);
+  };
+
   const handleChatRoomButtonClick = async (
     postId: number,
     userId: number,
@@ -138,10 +143,14 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
           },
         );
         if (response.status === 200) {
-          const { chatRoomId, studyId, studyName } = response.data;
+          const { chatRoomId, studyId, studyName, leaderId } = response.data;
           router.push(
-            `/chat/${chatRoomId}/study/${studyId}?studyName=${studyName}`,
+            `/chat/${chatRoomId}/study/${studyId}?studyName=${studyName}&studyLeaderId=${leaderId}`,
           );
+          // const { chatRoomId, studyId, studyName } = response.data;
+          // router.push(
+          //   `/chat/${chatRoomId}/study/${studyId}?studyName=${studyName}`,
+          // );
         } else {
           setAlertMessage(
             '채팅방 참가 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
@@ -166,7 +175,7 @@ const MyStudyCard = ({ post }: MyStudyCardProps) => {
   return (
     <div
       className="card bg-base-100 shadow-xl cursor-pointer hover:shadow-2xl transition-shadow w-full min-w-[330px] max-w-[330px] group h-[548px]"
-      onClick={() => router.push(`/community/study/${post.studyPostId}`)}
+      onClick={handleDetailButtonClick}
     >
       <figure className="px-4 pt-4">
         <Image

--- a/src/app/mypage/components/MyStudyView.tsx
+++ b/src/app/mypage/components/MyStudyView.tsx
@@ -177,10 +177,18 @@ const MyStudyView = () => {
 
   return (
     <div className="p-6 space-y-6 max-w-6xl mx-auto">
-      <div role="tablist" className="tabs tabs-lifted tabs-lg hover:tab-lifted">
+      <div
+        role="tablist"
+        aria-label=""
+        className="tabs tabs-lifted tabs-lg hover:tab-lifted"
+      >
         {Object.keys(tabConfigs).map(tab => (
           <button
             key={tab}
+            id={`tab-${tab}`}
+            role="tab"
+            aria-selected={activeTab === tab}
+            aria-controls={`tabpanel-${tab}`}
             onClick={() => handleTabClick(tab as keyof typeof tabConfigs)}
             className={`tab tab-lg text-xs sm:text-sm md:text-base hover:font-bold hover:text-md hover:text-black hover:shadow-lg ${
               activeTab === tab

--- a/src/app/mypage/components/Pagination.tsx
+++ b/src/app/mypage/components/Pagination.tsx
@@ -51,6 +51,7 @@ const Pagination = ({
           disabled={currentPage === 1}
           onClick={() => onPageChange(0)}
           className={'join-item btn text-gray-700'}
+          aria-label={'첫 페이지로 이동'}
         >
           <FaAngleDoubleLeft size={24} />
         </button>
@@ -58,6 +59,7 @@ const Pagination = ({
           disabled={currentPage === 1}
           onClick={() => onPageChange(currentPageZeroBased - 1)}
           className={'join-item btn text-gray-700'}
+          aria-label={'이전 페이지로 이동'}
         >
           <FaAngleLeft size={24} />
         </button>
@@ -76,6 +78,7 @@ const Pagination = ({
           disabled={currentPage === totalPages}
           onClick={() => onPageChange(currentPageZeroBased + 1)}
           className={'join-item btn text-gray-700'}
+          aria-label={'다음 페이지로 이동'}
         >
           <FaAngleRight size={24} />
         </button>
@@ -83,6 +86,7 @@ const Pagination = ({
           disabled={currentPage === totalPages}
           onClick={() => onPageChange(totalPages - 1)}
           className={'join-item btn text-gray-700'}
+          aria-label={'마지막 페이지로 이동'}
         >
           <FaAngleDoubleRight size={24} />
         </button>

--- a/src/app/signin/components/SignInForm.tsx
+++ b/src/app/signin/components/SignInForm.tsx
@@ -122,7 +122,7 @@ const SingInPage = () => {
               id="email"
               type="email"
               value={email}
-              placeholder="이메일을 입력해 주세요."
+              placeholder="example@example.com"
               onChange={e => {
                 setEmail(e.target.value);
                 setError('');
@@ -155,6 +155,9 @@ const SingInPage = () => {
               type="button"
               onClick={togglePasswordVisibility}
               className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+              aria-label={
+                passwordVisible ? '비밀번호 숨기기' : '비밀번호 보이기'
+              }
             >
               {passwordVisible ? (
                 <FaRegEye size={20} />

--- a/src/app/signup/components/SignUpForm.tsx
+++ b/src/app/signup/components/SignUpForm.tsx
@@ -357,7 +357,7 @@ const SignUpForm = () => {
               id="email"
               type="email"
               value={email}
-              placeholder="이메일을 입력해 주세요."
+              placeholder="example@example.com"
               onChange={e => {
                 setEmail(e.target.value);
                 setAuthCodeVerified(false); // 이메일 수정 시 인증 초기화
@@ -502,6 +502,9 @@ const SignUpForm = () => {
               type="button"
               onClick={togglePasswordVisibility}
               className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+              aria-label={
+                passwordVisible ? '비밀번호 숨기기' : '비밀번호 보이기'
+              }
             >
               {passwordVisible ? (
                 <FaRegEye size={20} />
@@ -518,6 +521,11 @@ const SignUpForm = () => {
           <label
             htmlFor="passwordCheck"
             className="block mb-2 font-semibold text-sm sm:text-base"
+            aria-label={
+              passwordCheckVisible
+                ? '비밀번호 확인 숨기기'
+                : '비밀번호 확인 보이기'
+            }
           >
             비밀번호 확인
           </label>

--- a/src/components/common/Confirm/index.tsx
+++ b/src/components/common/Confirm/index.tsx
@@ -63,22 +63,34 @@ const CustomConfirm = ({
       className="fixed inset-0 flex items-center justify-center bg-gray-500 bg-opacity-50 z-50"
     >
       <div className="bg-white p-6 rounded-lg shadow-lg w-[28rem] max-w-lg">
-        <p className="text-lg font-semibold text-center whitespace-pre-wrap break-words mb-4">
+        <p className="text-lg font-semibold text-center whitespace-pre-wrap break-words mb-6">
           {message}
         </p>
         {requirePasswordInput && (
-          <div className="relative mb-4">
+          <div className="relative mb-6">
+            <label
+              htmlFor="current-password"
+              className="block font-medium text-sm sm:text-base text-gray-500 mb-1"
+            >
+              현재 비밀번호
+            </label>
             <input
+              id="current-password"
               type={currentPasswordVisible ? 'text' : 'password'}
               value={currentPasswordValue}
               onChange={e => onCurrentPasswordChange(e.target.value)}
-              placeholder="현재 비밀번호를 입력해주세요"
+              placeholder="현재 비밀번호를 입력해 주세요."
               className="w-full input input-bordered px-4 py-2 focus:outline-teal-500 text-sm sm:text-base"
             />
             <button
               type="button"
               onClick={toggleCurrentPasswordVisibility}
-              className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+              className="absolute right-2 top-[calc(50%+0.8rem)] transform -translate-y-1/2 mr-2"
+              aria-label={
+                currentPasswordVisible
+                  ? '현재 비밀번호 숨기기'
+                  : '현재 비밀번호 보이기'
+              }
             >
               {currentPasswordVisible ? (
                 <FaRegEye size={20} />
@@ -90,18 +102,27 @@ const CustomConfirm = ({
         )}
 
         {requireNewPasswordInput && (
-          <div className="relative mb-4">
+          <div className="relative mb-6">
+            <label
+              htmlFor="current-password"
+              className="block font-medium text-sm sm:text-base text-gray-500 mb-1"
+            >
+              새 비밀번호
+            </label>
             <input
               type={newPasswordVisible ? 'text' : 'password'}
               value={newPasswordValue}
               onChange={e => onNewPasswordChange(e.target.value)}
-              placeholder="새 비밀번호를 입력해주세요"
+              placeholder="새 비밀번호를 입력해 주세요."
               className="w-full input input-bordered px-4 py-2 focus:outline-teal-500 text-sm sm:text-base"
             />
             <button
               type="button"
               onClick={toggleNewPasswordVisibility}
-              className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+              className="absolute right-2 top-[calc(50%-0.9rem)] transform -translate-y-1/2 mr-2"
+              aria-label={
+                newPasswordVisible ? '새 비밀번호 숨기기' : '새 비밀번호 보이기'
+              }
             >
               {newPasswordVisible ? (
                 <FaRegEye size={20} />
@@ -109,22 +130,38 @@ const CustomConfirm = ({
                 <FaRegEyeSlash size={20} />
               )}
             </button>
+            <p className="text-gray-500 mt-2 text-sm sm:text-base">
+              비밀번호는 최소 <b>8자 이상</b>이어야 하며,{' '}
+              <b>하나 이상의 영문자</b>,<b>숫자</b>, <b>특수문자</b>(예:
+              !@#$%^&*)를 포함해야 합니다.
+            </p>
           </div>
         )}
 
         {requireConfirmPasswordInput && (
-          <div className="relative mb-4">
+          <div className="relative mb-6">
+            <label
+              htmlFor="current-password"
+              className="block font-medium text-sm sm:text-base text-gray-500 mb-1"
+            >
+              새 비밀번호 확인
+            </label>
             <input
               type={confirmPasswordVisible ? 'text' : 'password'}
               value={confirmPasswordValue}
               onChange={e => onConfirmPasswordChange(e.target.value)}
-              placeholder="새 비밀번호 확인"
+              placeholder="새 비밀번호를 한 번 더 입력해 주세요."
               className="w-full input input-bordered px-4 py-2 focus:outline-teal-500 text-sm sm:text-base"
             />
             <button
               type="button"
               onClick={toggleConfirmPasswordVisibility}
-              className="absolute right-2 top-1/2 transform -translate-y-1/2 mr-2"
+              className="absolute right-2 top-[calc(50%+0.8rem)] transform -translate-y-1/2 mr-2"
+              aria-label={
+                confirmPasswordVisible
+                  ? '새 비밀번호 확인 숨기기'
+                  : '새 비밀번호 확인 보이기'
+              }
             >
               {confirmPasswordVisible ? (
                 <FaRegEye size={20} />

--- a/src/components/common/LoadingSpinner/index.tsx
+++ b/src/components/common/LoadingSpinner/index.tsx
@@ -1,6 +1,6 @@
 const LoadingSpinner = () => {
   return (
-    <div className="flex flex-col justify-center items-center h-20 mb-4">
+    <div className="flex flex-col justify-center items-center h-full mt-4 mb-4">
       <div className="animate-spin rounded-full h-[2.5rem] w-[2.5rem] min-h-[2.5rem] min-w-[2.5rem] border-t-2 border-b-2 border-teal-500"></div>
       <span className="mt-4 text-teal-500 text-center whitespace-pre-line sm:whitespace-nowrap">
         {'잠시만 기다려 주세요!\n 데이터를 불러오는 중입니다.'}

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -166,10 +166,11 @@ const Header = () => {
             <span className="block text-xl font-bold text-teal-500">
               <Image
                 src={'/devonoff-logo.png'}
-                alt={'DevOnOff logo'}
+                alt={'DevOnOff 로고'}
                 width={190}
                 height={190}
                 className="object-contain -mt-20"
+                priority
               />
             </span>
           </div>
@@ -244,7 +245,11 @@ const Header = () => {
           <FiBell size={24} />
         </button> */}
         <NotificationButton />
-        <button className="btn btn-ghost" onClick={toggleNav}>
+        <button
+          className="btn btn-ghost"
+          onClick={toggleNav}
+          aria-label={isNavOpen ? '메뉴 닫기' : '메뉴 열기'}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="h-6 w-6"
@@ -265,7 +270,11 @@ const Header = () => {
       {isNavOpen && (
         <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex justify-end">
           <div className="w-2/3 max-w-xs bg-white h-full p-6">
-            <button className="btn btn-ghost" onClick={toggleNav}>
+            <button
+              className="btn btn-ghost"
+              onClick={toggleNav}
+              aria-label={isNavOpen ? '메뉴 닫기' : '메뉴 열기'}
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 className="h-6 w-6"


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- Layout Shift
  - 페이지 이동 시 헤더가 왔다갔다 하는 Layout Shift 현상 발생
- UX
  - aria-label이 없는 버튼들이 많아 어떤 버튼인지 구분이 어려움
  - 이메일의 placeholder에 '이메일을 입력하세요' 라는 문구가 작성되어 있음
  - 비밀번호 변경 시 3개의 입력창에 대한 구분이 placeholder로만 되어있음
- 채팅방
  - 스터디장 표시가 디자인만 구현되어 있음

**TO-BE**
- Layout Shift
  - Header, Main, Footer 에 명시적인 높이 지정
  - main 영역에 최소 높이 계산값 지정
- UX
  - aria-label을 추가하여 접근성 향상
  - 이메일의 placeholder에 'example@example.com' 로 문구를 수정하여 예시를 보고 쉽게 이메일 입력 가능
  - 비밀번호 변경 시 3개의 입력창에 대한 구분을 label로 추가
- 채팅방
  - 채팅방 입장 시 서버로부터 studyLeaderId를 받아와, 그 값을 토대로 스터디장의 프로필 상단에 스터디장 표시