### PR TITLE
fix: 헤더, 채팅방, 마이페이지 리팩토링 / design: 홈화면, 푸터 디자인 개선 / feat: 알림창 모달 UI 구현

### DIFF
--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -2,7 +2,7 @@
 
 import { useGroupChat } from '@/hooks/useGroupChat';
 import MessageInput from './MessageInput';
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { useSearchParams } from 'next/navigation';
 import { useInView } from 'react-intersection-observer';
@@ -11,29 +11,110 @@ import CustomAlert from '@/components/common/Alert';
 
 interface ChatRoomProps {
   chatRoomId: string;
-  // studyId: string;
 }
 
-// interface Message {
-//   timestamp: string;
-//   content: string;
-//   user: {
-//     id: number;
-//     nickname: string;
-//     profileImageUrl: string;
-//   };
-// }
+interface Message {
+  timestamp: string;
+  content: string;
+  user: {
+    id: number;
+    nickname: string;
+    profileImageUrl: string;
+  };
+}
 
-// const ChatHeader = ({ studyName }: { studyName: string | null }) => {
-//   <>
-//     <div></div>
-//   </>;
-// };
+const ChatHeader = ({ studyName }: { studyName: string | null }) => (
+  <>
+    <div className="bg-gray-900 text-gray-100 p-4 flex items-center gap-2">
+      {['red', 'yellow', 'green'].map(color => (
+        <div key={color} className={`bg-${color}-500 w-3 h-3 rounded-full`} />
+      ))}
+    </div>
+    <div className="flex items-center bg-gray-100 p-3 border-b border-gray-300">
+      <div className="w-full text-lg text-center font-bold focus:outline-none bg-white border border-gray-300 rounded-md p-2">
+        {studyName}
+      </div>
+    </div>
+  </>
+);
+
+const UserProfile = memo(
+  ({
+    user,
+    isStudyLeader,
+  }: {
+    user: Message['user'];
+    isStudyLeader?: boolean;
+  }) => (
+    <div className="flex flex-col items-center min-w-[70px]">
+      {isStudyLeader && <FaCrown size={20} className="text-teal-500" />}
+      <img
+        src={user.profileImageUrl || 'http://via.placeholder.com/150'}
+        alt={`${user.nickname}'s profile`}
+        className="w-10 h-10 sm:w-12 sm:h-12 rounded-full"
+      />
+      <div
+        className="text-xs sm:text-sm text-gray-600 truncate max-w-[70px] mt-1"
+        title={user.nickname}
+      >
+        {user.nickname}
+      </div>
+    </div>
+  ),
+);
+
+const MessageBubble = memo(
+  ({ message, isOwnMessage }: { message: Message; isOwnMessage: boolean }) => {
+    const bubbleStyle = isOwnMessage
+      ? 'bg-blue-500 text-white self-end'
+      : 'bg-gray-200 text-black';
+    const timeStyle = isOwnMessage ? 'text-gray-300' : 'text-gray-500';
+    const arrowStyle = isOwnMessage
+      ? 'border-blue-500 right-[-6px] border-r-[10px] border-r-transparent'
+      : 'border-gray-200 left-[-6px] border-l-[10px] border-l-transparent';
+
+    return (
+      <div
+        className={`relative max-w-[70%] px-4 py-2 rounded-lg ${bubbleStyle} break-words`}
+      >
+        <div className="text-sm md:text-md">{message.content}</div>
+        <div className={`mt-2 text-xs sm:text-sm ${timeStyle}`}>
+          {new Date(message.timestamp).toLocaleTimeString('ko-KR', {
+            hour: '2-digit',
+            minute: '2-digit',
+          })}
+        </div>
+        <div
+          className={`absolute bottom-0 w-0 h-0 border-t-[20px] ${arrowStyle}`}
+        />
+      </div>
+    );
+  },
+);
+
+const formatDate = (timestamp: string) => {
+  return new Date(timestamp).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
+const isDateChanged = (
+  currentTimestamp: string,
+  prevTimestamp: string | null,
+) => {
+  const currentDate = new Date(currentTimestamp).toDateString();
+  const prevDate = prevTimestamp
+    ? new Date(prevTimestamp).toDateString()
+    : null;
+  return currentDate !== prevDate;
+};
 
 const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
   const searchParams = useSearchParams();
   const studyName = searchParams.get('studyName');
-  const studyLeaderId = Number(searchParams.get('studyLeaderId'));
+  const studyLeaderId = Number(searchParams.get('studyLeaderId')) || null;
 
   const { userInfo } = useAuthStore();
   const userId = userInfo?.id || 111;
@@ -64,41 +145,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
     threshold: 0,
     rootMargin: '50px 0px 0px 0px', // 상단 50px 이전에 트리거
   });
-
-  const handleFetchPreviousMessages = async () => {
-    if (
-      !hasNextPage ||
-      isFetchingNextPage ||
-      !chatContainerRef.current ||
-      isLoadingPrevMessages.current
-    )
-      return;
-
-    try {
-      isLoadingPrevMessages.current = true;
-      // const currentScrollHeight = chatContainerRef.current.scrollHeight;
-
-      await fetchNextPage();
-
-      // 스크롤 위치 유지를 위한 처리는 useEffect에서 수행
-    } catch (error) {
-      console.error('이전 메시지 로드 실패:', error);
-      setLoadError('이전 메시지를 가져오는 데 실패했습니다.');
-      isLoadingPrevMessages.current = false;
-    }
-  };
-
-  // Intersection Observer를 통한 이전 메시지 로드
-  useEffect(() => {
-    if (
-      inView &&
-      hasNextPage &&
-      !isFetchingNextPage &&
-      !isInitialLoad.current
-    ) {
-      handleFetchPreviousMessages();
-    }
-  }, [inView, hasNextPage, isFetchingNextPage]);
 
   // 최초 로드 시 스크롤을 맨 아래로
   useEffect(() => {
@@ -147,6 +193,41 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
     }
   }, [messages, userId]);
 
+  // Intersection Observer를 통한 이전 메시지 로드
+  useEffect(() => {
+    if (
+      inView &&
+      hasNextPage &&
+      !isFetchingNextPage &&
+      !isInitialLoad.current
+    ) {
+      handleFetchPreviousMessages();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage]);
+
+  const handleFetchPreviousMessages = async () => {
+    if (
+      !hasNextPage ||
+      isFetchingNextPage ||
+      !chatContainerRef.current ||
+      isLoadingPrevMessages.current
+    )
+      return;
+
+    try {
+      isLoadingPrevMessages.current = true;
+      // const currentScrollHeight = chatContainerRef.current.scrollHeight;
+
+      await fetchNextPage();
+
+      // 스크롤 위치 유지를 위한 처리는 useEffect에서 수행
+    } catch (error) {
+      console.error('이전 메시지 로드 실패:', error);
+      setLoadError('이전 메시지를 가져오는 데 실패했습니다.');
+      isLoadingPrevMessages.current = false;
+    }
+  };
+
   const handleSendMessage = async (content: string, file?: File) => {
     try {
       await sendMessage(content, file);
@@ -154,17 +235,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
       console.error('메시지 전송에 실패했습니다:', error);
       setShowAlert(true); // 전역적인 알림 표시 등으로 대체
     }
-  };
-
-  const isDateChanged = (
-    currentTimestamp: string,
-    prevTimestamp: string | null,
-  ) => {
-    const currentDate = new Date(currentTimestamp).toDateString();
-    const prevDate = prevTimestamp
-      ? new Date(prevTimestamp).toDateString()
-      : null;
-    return currentDate !== prevDate;
   };
 
   if (chatState.error) {
@@ -187,16 +257,7 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
   return (
     <div className="flex justify-center items-start h-[screen]">
       <div className="mt-1 w-[100%] max-w-5xl bg-white rounded-lg shadow-lg relative overflow-hidden">
-        <div className="bg-gray-900 text-gray-100 p-4 flex items-center gap-2">
-          <div className="bg-red-500 w-3 h-3 rounded-full"></div>
-          <div className="bg-yellow-500 w-3 h-3 rounded-full"></div>
-          <div className="bg-green-500 w-3 h-3 rounded-full"></div>
-        </div>
-        <div className="flex items-center bg-gray-100 p-3 border-b border-gray-300">
-          <div className="w-full text-lg text-center font-bold focus:outline-none bg-white border border-gray-300 rounded-md p-2">
-            {studyName}
-          </div>
-        </div>
+        <ChatHeader studyName={studyName} />
         <div
           ref={chatContainerRef}
           className="flex-1 h-[350px] sm:h-[400px] overflow-y-auto space-y-4 px-6 pb-6"
@@ -223,97 +284,33 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
             const showDate =
               !prevMessage ||
               isDateChanged(msg.timestamp, prevMessage?.timestamp);
+            const isOwnMessage = msg.user.id === userId;
 
             return (
               <div className="mt-4" key={msg.timestamp || idx}>
                 {showDate && (
                   <div className="text-center mb-4 font-base text-gray-500 text-sm md:text-md">
-                    {new Date(msg.timestamp).toLocaleDateString('ko-KR', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })}
+                    {formatDate(msg.timestamp)}
                   </div>
                 )}
 
                 <div
                   className={`flex items-end ${
-                    msg.user.id === userId ? 'justify-end' : 'justify-start'
+                    isOwnMessage ? 'justify-end' : 'justify-start'
                   }`}
                 >
-                  {msg.user.id !== userId && (
-                    <div className="flex flex-col items-center min-w-[70px]">
-                      {msg.user.id === studyLeaderId && (
-                        <FaCrown size={20} className="text-teal-500" />
-                      )}
-                      <img
-                        src={
-                          msg.user.profileImageUrl ||
-                          'http://via.placeholder.com/150'
-                        }
-                        alt={`${msg.user.id}'s profile`}
-                        className="w-10 h-10 sm:w-12 sm:h-12 rounded-full"
-                      />
-                      <div
-                        className="text-xs sm:text-sm text-gray-600 truncate max-w-[70px] mt-1"
-                        title={msg.user.nickname}
-                      >
-                        {msg.user.nickname}
-                      </div>
-                    </div>
-                  )}
-
-                  <div
-                    className={`relative max-w-[70%] px-4 py-2 rounded-lg ${
-                      msg.user.id === userId
-                        ? 'bg-blue-500 text-white self-end'
-                        : 'bg-gray-200 text-black'
-                    } break-words`}
-                  >
-                    <div className="text-sm md:text-md">{msg.content}</div>
-                    <div
-                      className={`mt-2 text-xs sm:text-sm ${
-                        msg.user.id === userId
-                          ? 'text-gray-300'
-                          : 'text-gray-500'
-                      }`}
-                    >
-                      {new Date(msg.timestamp).toLocaleTimeString('ko-KR', {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                      })}
-                    </div>
-                    <div
-                      className={`absolute bottom-0 w-0 h-0 border-t-[20px] ${
-                        msg.user.id === userId
-                          ? 'border-blue-500 right-[-6px] border-r-[10px] border-r-transparent'
-                          : 'border-gray-200 left-[-6px] border-l-[10px] border-l-transparent'
-                      }`}
+                  {!isOwnMessage && (
+                    <UserProfile
+                      user={msg.user}
+                      isStudyLeader={msg.user.id === studyLeaderId}
                     />
-                  </div>
-
-                  {msg.user.id === userId && (
-                    <div className="flex flex-col items-center min-w-[70px]">
-                      {/* 실제 스터디장 프로필에 표시하는 것으로 수정 예정 */}
-                      {msg.user.id === studyLeaderId && (
-                        <FaCrown size={20} className="text-teal-500" />
-                      )}
-                      {/* <FaCrown size={20} className="text-teal-500" /> */}
-                      <img
-                        src={
-                          msg.user.profileImageUrl ||
-                          'http://via.placeholder.com/150'
-                        }
-                        alt="My profile"
-                        className="w-10 h-10 sm:w-12 sm:h-12 rounded-full"
-                      />
-                      <div
-                        className="text-xs sm:text-sm text-gray-600 truncate max-w-[70px] mt-1"
-                        title={msg.user.nickname}
-                      >
-                        {msg.user.nickname}
-                      </div>
-                    </div>
+                  )}
+                  <MessageBubble message={msg} isOwnMessage={isOwnMessage} />
+                  {isOwnMessage && (
+                    <UserProfile
+                      user={msg.user}
+                      isStudyLeader={msg.user.id === studyLeaderId}
+                    />
                   )}
                 </div>
               </div>

--- a/src/app/mypage/[userId]/page.tsx
+++ b/src/app/mypage/[userId]/page.tsx
@@ -1,12 +1,16 @@
+import { Suspense } from 'react';
 import MyStudyView from '../components/MyStudyView';
 import UserInfoView from '../components/UserInfoView';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 
 const MyPage = async () => {
   try {
     return (
       <>
-        <UserInfoView />
-        <MyStudyView />
+        <Suspense fallback={<LoadingSpinner />}>
+          <UserInfoView />
+          <MyStudyView />
+        </Suspense>
       </>
     );
   } catch (error) {

--- a/src/app/mypage/components/MyStudyView.tsx
+++ b/src/app/mypage/components/MyStudyView.tsx
@@ -57,7 +57,7 @@ const MyStudyView = () => {
         desktop: '내가 속한 스터디',
       },
       myStudyPost: {
-        mobile: '나의\n스터디\n모집 글',
+        mobile: '나의\n스터디\n모집글',
         desktop: '나의 스터디 모집 글',
       },
       myInfoPost: {
@@ -179,16 +179,16 @@ const MyStudyView = () => {
     <div className="p-6 space-y-6 max-w-6xl mx-auto">
       <div
         role="tablist"
-        aria-label=""
+        aria-label="내 활동 탭 메뉴"
         className="tabs tabs-lifted tabs-lg hover:tab-lifted"
       >
         {Object.keys(tabConfigs).map(tab => (
           <button
             key={tab}
-            id={`tab-${tab}`}
             role="tab"
             aria-selected={activeTab === tab}
-            aria-controls={`tabpanel-${tab}`}
+            aria-controls={`panel-${tab}`}
+            tabIndex={activeTab === tab ? 0 : -1}
             onClick={() => handleTabClick(tab as keyof typeof tabConfigs)}
             className={`tab tab-lg text-xs sm:text-sm md:text-base hover:font-bold hover:text-md hover:text-black hover:shadow-lg ${
               activeTab === tab
@@ -200,8 +200,19 @@ const MyStudyView = () => {
           </button>
         ))}
       </div>
+
       <div className="p-4">
-        {renderTabContent()}
+        {Object.keys(tabConfigs).map(tab => (
+          <div
+            key={tab}
+            role="tabpanel"
+            id={`panel-${tab}`}
+            aria-labelledby={`tab-${tab}`}
+            hidden={activeTab !== tab}
+          >
+            {activeTab === tab && renderTabContent()}
+          </div>
+        ))}
         <Pagination
           totalElements={pagination.totalElements}
           pageSize={pagination.pageSize}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,5 @@
-const Home = () => {
-  return (
-    <div className="flex flex-col items-center justify-center min-h-[50vh] gap-4">
-      <h1 className="text-4xl font-bold">DevOnOff</h1>
-      <p className="text-xl">개발자 온오프라인 스터디 플랫폼</p>
-      <p>DevOnOff에 오신 것을 환영합니다!</p>
-      <p>개발자들과 함께 성장하는 공간입니다.</p>
-    </div>
-  );
-};
+import HomePage from '@/components/home/HomePage';
 
-export default Home;
+export default function Page() {
+  return <HomePage />;
+}

--- a/src/components/home/HomePage/index.tsx
+++ b/src/components/home/HomePage/index.tsx
@@ -1,0 +1,95 @@
+'use client';
+import React from 'react';
+import { PiHandTapFill } from 'react-icons/pi';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+
+type Card = { title: string; description: string };
+
+const FeatureCard = ({ title, description }: Card) => (
+  <div className="w-full p-6 rounded-lg bg-white shadow-lg hover:shadow-xl transition-shadow duration-300 border border-gray-100">
+    <h3 className="text-xl md:text-2xl font-bold text-gray-800 mb-3">
+      {title}
+    </h3>
+    <p className="text-gray-600 leading-relaxed">{description}</p>
+  </div>
+);
+const HomePage = () => {
+  const router = useRouter();
+  const StudyListButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    router.push('/community/study');
+  };
+
+  const features = [
+    {
+      title: '📚 스터디 모집부터 진행까지, 한 번에 해결!',
+      description:
+        'DevOnOff는 스터디 모집, 참여, 관리까지 모든 것을 간편하게 할 수 있는 올인원 플랫폼입니다. 더 이상 여러 서비스를 돌아다닐 필요 없이 한 곳에서 해결하세요!',
+    },
+    {
+      title: '💬 스터디원들과 실시간 소통, 언제든지 가능!',
+      description:
+        '실시간 채팅과 화상 채팅 기능을 통해 스터디원들과 언제든지 소통하며, 장소와 시간에 구애받지 않고 효율적으로 온라인 스터디를 진행해보세요.',
+    },
+    {
+      title: '💪 스터디 상위 랭킹 Top10 도전!',
+      description:
+        '온라인 스터디 참여율을 높여 스터디 상위 랭킹을 목표로 도전하세요. 서로를 자극하며 꾸준한 학습이 가능합니다!',
+    },
+    {
+      title: '🙋 개발 중 궁금한 점, 이제는 쉽게 해결!',
+      description:
+        '질문 게시판을 통해 스터디원들과 개발 관련 질문을 주고받으며 실시간으로 문제를 해결하세요. 여러분의 궁금증을 신속하게 해결할 수 있습니다.',
+    },
+    {
+      title: '🌱 개발 정보를 나누며 함께 성장하는 커뮤니티!',
+      description:
+        '정보 공유 게시판에서 유용한 개발 정보를 함께 나누고, 서로의 지식을 쌓으며 실력을 한층 더 향상시킬 수 있습니다.',
+    },
+  ];
+
+  return (
+    <div className="min-h-auto">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <div className="flex flex-col items-center text-center mb-8">
+          {/* <h1 className="text-4xl md:text-5xl font-bold text-gray-800 mb-6">
+            DevOnOff
+          </h1> */}
+          <Image
+            src={'/devonoff-logo.png'}
+            alt={'DevOnOff 로고'}
+            width={300}
+            height={300}
+            className="object-contain -mt-52 -mb-28"
+          />
+          <p className="text-lg text-gray-500 mb-8 whitespace-pre-line">
+            {
+              'DevOnOff는 Dev와 On/Off를 결합한 이름으로,\n 개발 스터디를 온라인과 온/오프라인 모두 지원하는 스마트한 개발 스터디 플랫폼입니다.'
+            }
+          </p>
+          <button
+            className="px-8 py-3 bg-gray-800 text-white rounded-full font-semibold hover:text-white hover:bg-teal-500 transition-colors duration-300 flex items-center gap-2 mx-auto"
+            onClick={StudyListButtonClick}
+          >
+            스터디 둘러보기
+            <PiHandTapFill size={22} />
+          </button>
+        </div>
+
+        {/* Features Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-4">
+          {features.map((feature, index) => (
+            <FeatureCard
+              key={index}
+              title={feature.title}
+              description={feature.description}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -1,22 +1,20 @@
 import React from 'react';
 import { FaGithub } from 'react-icons/fa';
+import { SiNotion } from 'react-icons/si';
 
 export default function Footer() {
   return (
-    <footer className="footer footer-center p-6 text-base-content bg-teal-50">
-      <div className="flex flex-col md:flex-row justify-center items-center w-full">
-        <div className="mb-6 md:mb-0 md:mr-12 text-center md:text-left">
-          <p className="font-medium text-lg">DevOnOff</p>
-          <p className="text-gray-700 mt-2">스마트한 개발 스터디 플랫폼</p>
-        </div>
-        <div className="text-center">
-          <p className="font-medium text-lg">Repository</p>
-          <div className="flex gap-6 mt-4 justify-center">
+    <footer className="footer footer-center p-6 text-base-content bg-gray-50">
+      <div className="flex flex-col md:flex-row justify-center items-start w-full gap-12 md:gap-52">
+        {/* Repository Section */}
+        <div className="text-center md:text-left">
+          <p className="font-medium text-lg mb-4">Repository</p>
+          <div className="flex flex-col gap-2">
             <a
               href="https://github.com/ZB-DevOnOff"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-800 hover:text-black flex items-center gap-2"
+              className="text-gray-700 hover:text-black flex items-center gap-2"
             >
               <FaGithub size={20} />
               DevOnOff
@@ -25,64 +23,60 @@ export default function Footer() {
               href="https://github.com/ZB-DevOnOff/FrontEnd"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-800 hover:text-black flex items-center gap-2"
+              className="text-gray-700 hover:text-black flex items-center gap-2"
             >
               <FaGithub size={20} />
               Frontend
             </a>
             <a
-              href="https://github.com/your-backend-repo"
+              href="https://github.com/ZB-DevOnOff/BackEnd"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-800 hover:text-black flex items-center gap-2"
+              className="text-gray-700 hover:text-black flex items-center gap-2"
             >
               <FaGithub size={20} />
               Backend
             </a>
           </div>
-          <div className="mt-6">
-            <p className="font-medium text-lg">Team Members</p>
-            <div className="flex flex-wrap gap-6 justify-center mt-3">
-              {[
-                {
-                  name: 'SwanyCastle',
-                  github: 'https://github.com/SwanyCastle',
-                },
-                { name: 'yoon627', github: 'https://github.com/yoon627' },
-                { name: 'hjkim22', github: 'https://github.com/hjkim22' },
-                { name: 'heekuukuu', github: 'https://github.com/heekuukuu' },
-                { name: 'sim0102', github: 'https://github.com/sim0102' },
-                { name: 'jyeoney', github: 'https://github.com/jyeoney' },
-              ].map((member, index) => (
-                <a
-                  key={index}
-                  href={member.github}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-gray-800 hover:text-black flex items-center gap-2"
-                >
-                  <FaGithub size={20} />
-                  {member.name}
-                </a>
-              ))}
-            </div>
+        </div>
+
+        <div className="text-center md:text-left">
+          <p className="font-medium text-lg mb-4">Team Members</p>
+          <div className="flex flex-col gap-2">
+            {[
+              { name: 'SwanyCastle', github: 'https://github.com/SwanyCastle' },
+              { name: 'yoon627', github: 'https://github.com/yoon627' },
+              { name: 'hjkim22', github: 'https://github.com/hjkim22' },
+              { name: 'heekuukuu', github: 'https://github.com/heekuukuu' },
+              { name: 'sim0102', github: 'https://github.com/sim0102' },
+              { name: 'jyeoney', github: 'https://github.com/jyeoney' },
+            ].map((member, index) => (
+              <a
+                key={index}
+                href={member.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-700 hover:text-black flex items-center gap-2"
+              >
+                <FaGithub size={20} />
+                {member.name}
+              </a>
+            ))}
           </div>
-          <div className="mt-2 pt-6">
-            <div className="flex justify-center gap-4">
-              {/* <a href="/terms" className="text-sm text-gray-700 hover:underline">
-              이용약관
-            </a>
+        </div>
+
+        <div className="text-center md:text-left">
+          <p className="font-medium text-lg mb-4">Notion</p>
+          <div className="flex flex-col gap-2">
             <a
-              href="/privacy"
-              className="text-sm text-gray-700 hover:underline"
+              href="https://www.notion.so/DevOnOff-f315721711c84a79ad3e7e3daae98c8b?pvs=4"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-700 hover:text-black flex items-center gap-2"
             >
-              개인정보처리방침
-            </a> */}
-              {/* <p className="font-semibold">
-              Copyright © {new Date().getFullYear()} - All rights reserved by
+              <SiNotion size={20} />
               DevOnOff
-            </p> */}
-            </div>
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/layout/Header/NotificationModal.tsx
+++ b/src/components/layout/Header/NotificationModal.tsx
@@ -1,0 +1,57 @@
+import { FaCheck } from 'react-icons/fa';
+
+type NotificationModalProps = {
+  notifications: { message: string; isRead: boolean }[];
+  onClose: () => void;
+  // onAllMessagesRead: () => void
+};
+const NotificationModal = ({
+  notifications,
+  onClose,
+  // onAllMessagesRead,
+}: NotificationModalProps) => {
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={handleBackdropClick} />
+      <div className="absolute top-16 right-16 lg:right-48 z-50">
+        <div className="bg-white rounded-lg shadow-custom-strong p-6 w-full max-w-xs">
+          <h2 className="text-lg font-bold mb-4">알림</h2>
+          {notifications.length > 0 && (
+            <div className="flex justify-end mb-4 text-gray-600">
+              <button
+                className="bg-white text-sm hover:text-teal-500 flex items-center space-x-2"
+                // onClick={onMarkAllAsRead}
+              >
+                <FaCheck size={16} className="mr-2" />
+                모두 읽음 처리
+              </button>
+            </div>
+          )}
+
+          {notifications.length > 0 ? (
+            <ul className="space-y-2">
+              {notifications.map((notification, index) => (
+                <li
+                  key={index}
+                  className={`p-3 border-b border-gray-200 cursor-pointer hover:bg-gray-200 ${notification.isRead ? 'bg-gray-100 text-gray-700 opacity-70' : 'text-gray-800'}`}
+                >
+                  {notification.message}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-gray-500">새로운 알림이 없습니다.</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default NotificationModal;

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -5,12 +5,197 @@ import Image from 'next/image';
 import { useAuthStore } from '@/store/authStore';
 import { usePathname } from 'next/navigation';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import CustomConfirm from '@/components/common/Confirm';
 import CustomAlert from '@/components/common/Alert';
 import { FiBell } from 'react-icons/fi';
 import axiosInstance from '@/utils/axios';
 import handleApiError from '@/utils/handleApiError';
+import NotificationModal from './NotificationModal';
+
+type NavigationItem = {
+  path: string;
+  label: string;
+  id: string;
+};
+
+const NAVIGATION_ITEMS: NavigationItem[] = [
+  { path: '/community/study', label: '스터디', id: 'study' },
+  { path: '/community/info', label: '정보 공유', id: 'info' },
+  { path: '/community/qna', label: 'Q&A', id: 'qna' },
+  { path: '/community/ranking', label: '랭킹', id: 'ranking' },
+];
+
+const Logo = () => (
+  <Link
+    href="/"
+    className="btn btn-ghost text-base-content text-center overflow-hidden"
+  >
+    <div className="flex flex-col items-center">
+      <span className="block text-xs text-black">
+        스마트한 개발 스터디 플랫폼
+      </span>
+      <span className="block text-xl font-bold text-teal-500">
+        <Image
+          src={'/devonoff-logo.png'}
+          alt={'DevOnOff 로고'}
+          width={185}
+          height={185}
+          className="object-contain -mt-20"
+          priority
+        />
+      </span>
+    </div>
+  </Link>
+);
+
+const NotificationButton = ({
+  count,
+  onClick,
+}: {
+  count: number;
+  onClick: () => void;
+}) => (
+  <button className="btn btn-ghost relative" onClick={onClick}>
+    <FiBell size={24} />
+    {count > 0 && (
+      <div className="absolute -top-1 -right-0.5 bg-customRed text-white rounded-full min-w-5 h-5 px-1 flex items-center justify-center text-xs">
+        {count > 99 ? '99+' : count}
+      </div>
+    )}
+  </button>
+);
+
+const Navigation = ({
+  items,
+  activeMenu,
+  onMenuClick,
+  className = '',
+  itemClassName = '',
+}: {
+  items: NavigationItem[];
+  activeMenu: string;
+  onMenuClick: (menu: string) => void;
+  className?: string;
+  itemClassName?: string;
+}) => (
+  <nav className={className}>
+    {items.map(item => (
+      <Link
+        key={item.id}
+        href={item.path}
+        className={`btn ${itemClassName} ${activeMenu === item.id ? 'btn-active' : ''}`}
+        onClick={() => onMenuClick(item.id)}
+      >
+        {item.label}
+      </Link>
+    ))}
+  </nav>
+);
+
+const AuthLinks = ({
+  isSignedIn,
+  userInfo,
+  onSignOut,
+  activeMenu,
+  onMenuClick,
+  className = '',
+  linkClassName = '',
+}: {
+  isSignedIn: boolean;
+  userInfo: any;
+  onSignOut: () => void;
+  activeMenu: string;
+  onMenuClick: (menu: string) => void;
+  className?: string;
+  linkClassName?: string;
+}) => (
+  <div className={className}>
+    {isSignedIn ? (
+      <>
+        <Link
+          href={`/mypage/${userInfo?.id}`}
+          className={`btn ${linkClassName} ${activeMenu === 'mypage' ? 'btn-active' : ''}`}
+          onClick={() => onMenuClick('mypage')}
+        >
+          마이페이지
+        </Link>
+        <button className={`btn ${linkClassName}`} onClick={onSignOut}>
+          로그아웃
+        </button>
+      </>
+    ) : (
+      <>
+        <Link href="/signin" className={`btn ${linkClassName}`}>
+          로그인
+        </Link>
+        <Link href="/signup" className={`btn ${linkClassName}`}>
+          회원가입
+        </Link>
+      </>
+    )}
+  </div>
+);
+
+const MobileMenu = ({
+  isOpen,
+  onClose,
+  children,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex justify-end">
+      <div ref={menuRef} className="w-2/3 max-w-xs bg-white h-full p-6">
+        <button
+          className="btn btn-ghost"
+          onClick={onClose}
+          aria-label="메뉴 닫기"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+};
 
 const Header = () => {
   const { isSignedIn, setIsSignedIn, userInfo, resetStore } = useAuthStore();
@@ -25,15 +210,34 @@ const Header = () => {
   const [isNavOpen, setIsNavOpen] = useState(false);
   const [activeMenu, setActiveMenu] = useState<string>('');
 
-  const [notificationCount] = useState(99);
+  const [isNotificationModalOpen, setNotificationModalOpen] = useState(false);
+  const [notifications] = useState([
+    { message: '새로운 댓글이 달렸습니다.', isRead: true },
+    { message: '스터디 신청이 승인되었습니다.', isRead: false },
+    { message: '스터디가 개설되었습니다.', isRead: true },
+  ]);
+  const [notificationCount] = useState(notifications.length);
 
   const pathname = usePathname();
   const router = useRouter();
+
+  useEffect(() => {
+    const storedSignedIn = useAuthStore.getState().isSignedIn;
+    console.log('로그인 상태는', storedSignedIn);
+    setIsSignedIn(storedSignedIn);
+    setIsLoading(false);
+  }, [setIsSignedIn]);
+
+  useEffect(() => {
+    console.log(`닉네임: ${userInfo?.nickname}`);
+    console.log(`profileImageUrl: ${userInfo?.profileImageUrl}`);
+  }, [userInfo]);
 
   // pathname이 변경될 때마다 현재 활성화된 메뉴 설정
   useEffect(() => {
     const handleRouteChange = () => {
       window.scrollTo(0, 0);
+      document.body.style.overflow = 'auto';
     };
 
     // pathname이 변경될 때마다 스크롤 처리
@@ -54,28 +258,17 @@ const Header = () => {
     }
   }, [pathname]);
 
-  useEffect(() => {
-    document.body.style.overflow = 'auto';
-  }, []);
-
-  const NotificationButton = () => (
-    <button className="btn btn-ghost relative">
-      <FiBell size={24} />
-      {notificationCount > 0 && (
-        <div className="absolute -top-1 -right-0.5 bg-customRed text-white rounded-full min-w-5 h-5 px-1 flex items-center justify-center text-xs">
-          {notificationCount > 99 ? '99+' : notificationCount}
-        </div>
-      )}
-    </button>
-  );
+  const toggleNotificationModal = () => {
+    setNotificationModalOpen(prev => !prev);
+  };
 
   const toggleNav = () => {
     setIsNavOpen(!isNavOpen);
-    if (isNavOpen) {
-      document.body.style.overflow = 'auto';
-    } else {
-      document.body.style.overflow = 'hidden';
-    }
+    // if (isNavOpen) {
+    //   document.body.style.overflow = 'auto';
+    // } else {
+    //   document.body.style.overflow = 'hidden';
+    // }
   };
 
   const handleMenuClick = (menu: string) => {
@@ -84,18 +277,6 @@ const Header = () => {
     document.body.style.overflow = 'auto';
     window.scrollTo(0, 0);
   };
-
-  useEffect(() => {
-    const storedSignedIn = useAuthStore.getState().isSignedIn;
-    console.log('로그인 상태는', storedSignedIn);
-    setIsSignedIn(storedSignedIn);
-    setIsLoading(false);
-  }, [setIsSignedIn]);
-
-  useEffect(() => {
-    console.log(`닉네임: ${userInfo?.nickname}`);
-    console.log(`profileImageUrl: ${userInfo?.profileImageUrl}`);
-  }, [userInfo]);
 
   const showSignOutConfirm = () => {
     setConfirmMessage('로그아웃 하시겠습니까?');
@@ -131,25 +312,6 @@ const Header = () => {
       }
     } catch (error: any) {
       handleApiError(error, showErrorAlert);
-      // const { status } = error.response;
-      // if (error.response) {
-      //   if (status === 401) {
-      //     setAlertMessage('액세스 토큰이 없어 로그아웃을 할 수 없습니다.');
-      //   } else if (status === 400) {
-      //     setAlertMessage('로그아웃에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-      //   } else if (status === 404) {
-      //     setAlertMessage('사용자를 찾을 수 없습니다.');
-      //   } else {
-      //     setAlertMessage(
-      //       '서버에 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
-      //     );
-      //   }
-      // } else {
-      //   setAlertMessage(
-      //     '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',
-      //   );
-      // }
-      // setShowAlert(true);
     } finally {
       setShowConfirm(false);
     }
@@ -158,93 +320,41 @@ const Header = () => {
   return (
     <header className="navbar bg-base-100 shadow-md fixed w-full z-40">
       <div className="navbar-start">
-        <Link href="/" className="btn btn-ghost text-base-content text-center">
-          <div>
-            <span className="block text-xs text-black">
-              스마트한 개발 스터디 플랫폼
-            </span>
-            <span className="block text-xl font-bold text-teal-500">
-              <Image
-                src={'/devonoff-logo.png'}
-                alt={'DevOnOff 로고'}
-                width={190}
-                height={190}
-                className="object-contain -mt-20"
-                priority
-              />
-            </span>
-          </div>
-        </Link>
+        <Logo />
       </div>
 
-      <div className="navbar-center hidden lg:flex">
-        <div className="join">
-          <Link
-            href="/community/study"
-            className={`btn join-item ${activeMenu === 'study' ? 'btn-active' : ''}`}
-            onClick={() => handleMenuClick('study')}
-          >
-            스터디
-          </Link>
-          <Link
-            href="/community/info"
-            className={`btn join-item ${activeMenu === 'info' ? 'btn-active' : ''}`}
-            onClick={() => handleMenuClick('info')}
-          >
-            정보 공유
-          </Link>
-          <Link
-            href="/community/qna"
-            className={`btn join-item ${activeMenu === 'qna' ? 'btn-active' : ''}`}
-            onClick={() => handleMenuClick('qna')}
-          >
-            Q&A
-          </Link>
-          <Link
-            href="/community/ranking"
-            className={`btn join-item ${activeMenu === 'ranking' ? 'btn-active' : ''}`}
-            onClick={() => handleMenuClick('ranking')}
-          >
-            랭킹
-          </Link>
-        </div>
+      <div className="navbar-center hidden lg:block">
+        <Navigation
+          items={NAVIGATION_ITEMS}
+          activeMenu={activeMenu}
+          onMenuClick={handleMenuClick}
+          className="join"
+          itemClassName="join-item"
+        />
       </div>
 
       <div className="navbar-end hidden lg:flex space-x-2">
-        {/* <button className="btn btn-ghost">
-          <FiBell size={24} />
-        </button> */}
-        <NotificationButton />
-        {isSignedIn ? (
-          <>
-            <Link
-              href={`/mypage/${userInfo?.id}`}
-              className={`btn btn-ghost ${activeMenu === 'mypage' ? 'btn-active' : ''}`}
-              onClick={() => handleMenuClick('mypage')}
-            >
-              마이페이지
-            </Link>
-            <button className="btn btn-ghost" onClick={showSignOutConfirm}>
-              로그아웃
-            </button>
-          </>
-        ) : (
-          <>
-            <Link href="/signin" className="btn btn-ghost">
-              로그인
-            </Link>
-            <Link href="/signup" className="btn btn-ghost">
-              회원가입
-            </Link>
-          </>
-        )}
+        <NotificationButton
+          count={notificationCount}
+          onClick={toggleNotificationModal}
+        />
+        <AuthLinks
+          isSignedIn={isSignedIn}
+          userInfo={userInfo}
+          onSignOut={showSignOutConfirm}
+          activeMenu={activeMenu}
+          onMenuClick={handleMenuClick}
+          className="flex space-x-2"
+          linkClassName="btn-ghost"
+        />
       </div>
 
+      {/* 모바일 네브바 */}
       <div className="navbar-end lg:hidden">
-        {/* <button className="btn btn-ghost">
-          <FiBell size={24} />
-        </button> */}
-        <NotificationButton />
+        <NotificationButton
+          count={notificationCount}
+          onClick={toggleNotificationModal}
+        />
         <button
           className="btn btn-ghost"
           onClick={toggleNav}
@@ -267,102 +377,33 @@ const Header = () => {
         </button>
       </div>
 
-      {isNavOpen && (
-        <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex justify-end">
-          <div className="w-2/3 max-w-xs bg-white h-full p-6">
-            <button
-              className="btn btn-ghost"
-              onClick={toggleNav}
-              aria-label={isNavOpen ? '메뉴 닫기' : '메뉴 열기'}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-6 w-6"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-
-            <div className="flex flex-col mt-8 space-y-4">
-              <Link
-                href="/community/study"
-                className={`btn ${activeMenu === 'study' ? 'btn-active' : ''}`}
-                onClick={() => handleMenuClick('study')}
-              >
-                스터디
-              </Link>
-              <Link
-                href="/community/info"
-                className={`btn ${activeMenu === 'info' ? 'btn-active' : ''}`}
-                onClick={() => handleMenuClick('info')}
-              >
-                정보 공유
-              </Link>
-              <Link
-                href="/community/qna"
-                className={`btn ${activeMenu === 'qna' ? 'btn-active' : ''}`}
-                onClick={() => handleMenuClick('qna')}
-              >
-                Q&A
-              </Link>
-              <Link
-                href="/community/ranking"
-                className={`btn ${activeMenu === 'ranking' ? 'btn-active' : ''}`}
-                onClick={() => handleMenuClick('ranking')}
-              >
-                랭킹
-              </Link>
-            </div>
-
-            <div className="border-t border-gray-200 my-4" />
-
-            <div className="flex flex-col space-y-4">
-              {isSignedIn ? (
-                <>
-                  <Link
-                    href={`/mypage/${userInfo?.id}`}
-                    className={`btn ${activeMenu === 'mypage' ? 'btn-active' : ''}`}
-                    onClick={() => handleMenuClick('mypage')}
-                  >
-                    마이페이지
-                  </Link>
-                  <button
-                    className="btn btn-ghost"
-                    onClick={showSignOutConfirm}
-                  >
-                    로그아웃
-                  </button>
-                </>
-              ) : (
-                <>
-                  <Link
-                    href="/signin"
-                    className="btn"
-                    onClick={() => handleMenuClick('signin')}
-                  >
-                    로그인
-                  </Link>
-                  <Link
-                    href="/signup"
-                    className="btn"
-                    onClick={() => handleMenuClick('signup')}
-                  >
-                    회원가입
-                  </Link>
-                </>
-              )}
-            </div>
-          </div>
+      <MobileMenu isOpen={isNavOpen} onClose={toggleNav}>
+        <div className="flex flex-col mt-8 space-y-4">
+          <Navigation
+            items={NAVIGATION_ITEMS}
+            activeMenu={activeMenu}
+            onMenuClick={handleMenuClick}
+            className="flex flex-col space-y-4"
+          />
+          <div className="border-t border-gray-200 my-4" />
+          <AuthLinks
+            isSignedIn={isSignedIn}
+            userInfo={userInfo}
+            onSignOut={showSignOutConfirm}
+            activeMenu={activeMenu}
+            onMenuClick={handleMenuClick}
+            className="flex flex-col space-y-4"
+          />
         </div>
+      </MobileMenu>
+
+      {isNotificationModalOpen && (
+        <NotificationModal
+          notifications={notifications}
+          onClose={toggleNotificationModal}
+        />
       )}
+
       {showConfirm && (
         <CustomConfirm
           message={confirmMessage}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,10 @@ export default {
         foreground: 'var(--foreground)',
         customRed: '#FF364A ',
       },
+      boxShadow: {
+        'custom-strong':
+          '0 -2px 8px rgba(0, 0, 0, 0.1), 0 4px 12px rgba(0, 0, 0, 0.2)',
+      },
     },
   },
   daisyui: {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 마이페이지
  -  lighthouse 에서 aria 속성의 값이 올바르지 않다는 에러가 뜸
  - 마이페이지 이동 시 로딩 UI가 보이지 않아 페이지 이동이 되고 있는지 확인 불가능
- 채팅방
  - 컴포넌트 분리되어있지 않음
  - MessageBubble, UserProfile 컴포넌트의 내용들이 반복적으로 사용되어 불필요한 리렌더링 발생 가능
- 알림창
  - 알림 버튼만 구현하고 모달창 구현하지 않음
- 헤더
  - 컴포넌트가 분리되어 있지 않아 코드의 가독성이 떨어짐
- 홈화면
  - 기본적인 소개 내용이 적혀있음
- 푸터
  - 정렬이 깔끔하게 되지 않고, 배경색이 튐

**TO-BE**
- 마이페이지
  - 탭 버튼의 aria 속성 수정 / 모든 탭 패널을 렌더링하고 hidden 속성으로 제어
  - 마이페이지 이동 시 Suspense 로딩 UI를 보여주어 페이지 이동이 되고 있는지 사용자가 확인 가능
- 채팅방
  - 메시지 조각별로 컴포넌트 분리
  - `React.memo` 를 사용하여 MessageBubble, UserProfile 컴포넌트의 props가 변경되지 않았을 때 리렌더링을 방지
- 알림창
  - 알림버튼 클릭 시 모달을 띄우고, 바깥쪽 여백을 클릭하면 모달창 사라짐
- 헤더
  - 웹환경/모바일 환경 등에 따라 컴포넌트 분리
- 홈화면
  - 플랫폼 소개 내용 추가 및 스터디 둘러보기 버튼 추가
  - src/app/page.tsx는 서버컴포넌트로 구현 하고 HomePage는 클라이언트 컴포넌트로 분리하여 import
- 푸터
  - 세가지 카테고리로 나누어 그 안에서는 세로 정렬 및 배경색 옅은 회색으로 수정