### PR TITLE
feat: 닉네임 검증 로직 구체화, 로그인 상태일 때만 알림 버튼 표시

### DIFF
--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -8,13 +8,15 @@ import { useSearchParams } from 'next/navigation';
 import { useInView } from 'react-intersection-observer';
 import { FaCrown } from 'react-icons/fa';
 import CustomAlert from '@/components/common/Alert';
+import Image from 'next/image';
 
 interface ChatRoomProps {
   chatRoomId: string;
 }
 
 interface Message {
-  timestamp: string;
+  id: number;
+  createdAt: string;
   content: string;
   user: {
     id: number;
@@ -48,10 +50,17 @@ const UserProfile = memo(
   }) => (
     <div className="flex flex-col items-center min-w-[70px]">
       {isStudyLeader && <FaCrown size={20} className="text-teal-500" />}
-      <img
+      {/* <img
         src={user.profileImageUrl || 'http://via.placeholder.com/150'}
         alt={`${user.nickname}'s profile`}
-        className="w-10 h-10 sm:w-12 sm:h-12 rounded-full"
+        className="w-10 h-10 sm:w-12 sm:h-12 rounded-full object-cover"
+      /> */}
+      <Image
+        src={user.profileImageUrl || 'http://via.placeholder.com/150'}
+        alt={`${user.nickname}'s profile`}
+        width={48}
+        height={48}
+        className="w-10 h-10 sm:w-12 sm:h-12 rounded-full object-cover"
       />
       <div
         className="text-xs sm:text-sm text-gray-600 truncate max-w-[70px] mt-1"
@@ -62,6 +71,8 @@ const UserProfile = memo(
     </div>
   ),
 );
+
+UserProfile.displayName = 'UserProfile';
 
 const MessageBubble = memo(
   ({ message, isOwnMessage }: { message: Message; isOwnMessage: boolean }) => {
@@ -79,7 +90,7 @@ const MessageBubble = memo(
       >
         <div className="text-sm md:text-md">{message.content}</div>
         <div className={`mt-2 text-xs sm:text-sm ${timeStyle}`}>
-          {new Date(message.timestamp).toLocaleTimeString('ko-KR', {
+          {new Date(message.createdAt).toLocaleTimeString('ko-KR', {
             hour: '2-digit',
             minute: '2-digit',
           })}
@@ -92,8 +103,10 @@ const MessageBubble = memo(
   },
 );
 
-const formatDate = (timestamp: string) => {
-  return new Date(timestamp).toLocaleDateString('ko-KR', {
+MessageBubble.displayName = 'MessageBubble';
+
+const formatDate = (createdAt: string) => {
+  return new Date(createdAt).toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -101,12 +114,12 @@ const formatDate = (timestamp: string) => {
 };
 
 const isDateChanged = (
-  currentTimestamp: string,
-  prevTimestamp: string | null,
+  currentCreatedAt: string,
+  prevCreatedAt: string | null,
 ) => {
-  const currentDate = new Date(currentTimestamp).toDateString();
-  const prevDate = prevTimestamp
-    ? new Date(prevTimestamp).toDateString()
+  const currentDate = new Date(currentCreatedAt).toDateString();
+  const prevDate = prevCreatedAt
+    ? new Date(prevCreatedAt).toDateString()
     : null;
   return currentDate !== prevDate;
 };
@@ -172,6 +185,7 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
     }
   }, [messages]);
 
+  // 새 메시지 추가 시 스크롤 위치
   useEffect(() => {
     if (
       chatContainerRef.current &&
@@ -283,14 +297,14 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
             const prevMessage = messages[idx - 1] || null;
             const showDate =
               !prevMessage ||
-              isDateChanged(msg.timestamp, prevMessage?.timestamp);
+              isDateChanged(msg.createdAt, prevMessage?.createdAt);
             const isOwnMessage = msg.user.id === userId;
 
             return (
-              <div className="mt-4" key={msg.timestamp || idx}>
+              <div className="mt-4" key={msg.id || idx}>
                 {showDate && (
                   <div className="text-center mb-4 font-base text-gray-500 text-sm md:text-md">
-                    {formatDate(msg.timestamp)}
+                    {formatDate(msg.createdAt)}
                   </div>
                 )}
 

--- a/src/app/mypage/components/UserInfoView.tsx
+++ b/src/app/mypage/components/UserInfoView.tsx
@@ -12,6 +12,8 @@ import { FaCircle } from 'react-icons/fa';
 import { RiLockPasswordFill } from 'react-icons/ri';
 import handleApiError from '@/utils/handleApiError';
 
+const MAX_NICKNAME_LENGTH = 20;
+
 const UserInfoView = () => {
   const { userInfo, setUserInfo, resetStore } = useAuthStore();
   const [nickname, setNickname] = useState('');
@@ -100,27 +102,6 @@ const UserInfoView = () => {
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert);
-        // if (error.response) {
-        //   const { status, errorMessage } = error;
-
-        //   if (status === 404) {
-        //     setAlertMessage(errorMessage);
-        //     setShowAlert(true);
-        //   } else if (status === 500) {
-        //     setAlertMessage(errorMessage);
-        //     setShowAlert(true);
-        //   } else {
-        //     setAlertMessage(
-        //       '프로필 이미지를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.',
-        //     );
-        //     setShowAlert(true);
-        //   }
-        // } else {
-        //   setAlertMessage(
-        //     '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-        //   );
-        //   setShowAlert(true);
-        // }
       } finally {
         setShowConfirm(false);
       }
@@ -168,37 +149,6 @@ const UserInfoView = () => {
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert);
-        // if (error.response) {
-        //   const { status, errorMessage } = error;
-        //   console.log(`error: ${error.response.data}`);
-
-        //   if (status === 404) {
-        //     setAlertMessage(errorMessage);
-        //     setShowAlert(true);
-        //   } else if (status === 500) {
-        //     setAlertMessage(errorMessage);
-        //     setShowAlert(true);
-        //   }
-        //   // else if (status === 401) {
-        //   //   console.log('토큰 문제 발생. 로그인이 필요합니다.');
-        //   //   router.push('/signin');
-        //   //   resetStore();
-        //   // }
-        //   // else if (status === 401) {
-        //   //   setAlertMessage('로그인이 필요합니다.');
-        //   // }
-        //   else {
-        //     setAlertMessage(
-        //       '프로필 이미지를 변경하지 못했습니다. 잠시 후 다시 시도해주세요.',
-        //     );
-        //     setShowAlert(true);
-        //   }
-        // } else {
-        //   setAlertMessage(
-        //     '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-        //   );
-        //   setShowAlert(true);
-        // }
       } finally {
         setShowConfirm(false);
       }
@@ -233,6 +183,26 @@ const UserInfoView = () => {
       try {
         if (!nickname || nickname.trim().length === 0) {
           setAlertMessage('닉네임을 입력해주세요.');
+          setShowAlert(true);
+          return;
+        }
+
+        // 닉네임 길이 검증 (2-20자)
+        if (nickname.length < 2) {
+          setAlertMessage('닉네임은 최소 2자 이상이어야 합니다.');
+          setShowAlert(true);
+          return;
+        }
+
+        if (nickname.length > MAX_NICKNAME_LENGTH) {
+          setAlertMessage('닉네임은 최대 20자까지 입력 가능합니다.');
+          setShowAlert(true);
+          return;
+        }
+
+        if (nickname === '탈퇴한 회원') {
+          setAlertMessage('사용할 수 없는 닉네임입니다.');
+          setShowAlert(true);
           return;
         }
 
@@ -252,28 +222,6 @@ const UserInfoView = () => {
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert);
-        // if (error) {
-        //   const { status, errorMessage, errorCode } = error;
-
-        //   if (status === 404) {
-        //     setAlertMessage(errorMessage);
-        //     setShowAlert(true);
-        //   } else if (
-        //     status === 400 &&
-        //     errorCode === 'NICKNAME_ALREADY_REGISTERED'
-        //   ) {
-        //     setAlertMessage('이미 사용 중인 닉네임입니다.');
-        //     setShowAlert(true);
-        //   } else {
-        //     setAlertMessage('닉네임 변경에 실패했습니다. 다시 시도해주세요.');
-        //     setShowAlert(true);
-        //   }
-        // } else {
-        //   setAlertMessage(
-        //     '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-        //   );
-        //   setShowAlert(true);
-        // }
       } finally {
         setShowConfirm(false);
       }
@@ -321,23 +269,6 @@ const UserInfoView = () => {
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert, changePasswordErrorCodeHandlers);
-        // if (error.response) {
-        //   const { status, errorMessage } = error;
-        //   if (status === 400) {
-        //     setAlertMessage(
-        //       errorMessage || '현재 비밀번호가 올바르지 않습니다.',
-        //     );
-        //   } else {
-        //     setAlertMessage(
-        //       '서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
-        //     );
-        //   }
-        // } else {
-        //   setAlertMessage(
-        //     '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-        //   );
-        // }
-        // setShowAlert(true);
       } finally {
         setShouldChangePassword(false);
         setShowConfirm(false);
@@ -398,30 +329,6 @@ const UserInfoView = () => {
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert, withdrawalErrorCodeHandlers);
-        // if (error.response) {
-        //   const { status, errorCode } = error;
-        //   console.log('error:' + error.response);
-        //   if (status === 400) {
-        //     if (errorCode === 'INVALID_PASSWORD') {
-        //       setAlertMessage(
-        //         '비밀번호가 일치하지 않습니다. 입력한 내용을 다시 확인해 주세요.',
-        //       );
-        //     } else {
-        //       setAlertMessage('비밀번호 형식이 올바르지 않습니다.');
-        //     }
-        //   } else if (status === 404) {
-        //     setAlertMessage('사용자를 찾을 수 없습니다.');
-        //   } else {
-        //     setAlertMessage(
-        //       '서버에 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
-        //     );
-        //   }
-        // } else {
-        //   setAlertMessage(
-        //     '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-        //   );
-        // }
-        // setShowAlert(true);
       } finally {
         setShouldWithdrawal(false);
         setShowConfirm(false);

--- a/src/app/signin/components/SignInForm.tsx
+++ b/src/app/signin/components/SignInForm.tsx
@@ -64,25 +64,6 @@ const SingInPage = () => {
         setError,
         signInErrorCodeHandlers,
       );
-      // if (error.response) {
-      //   const { status, data } = error.response;
-      //   console.log(`status: ${status}`);
-      //   const errorCode = data?.errorCode;
-      //   console.log(`errorRes: ${errorCode}`);
-      //   if (status === 401) {
-      //     setError(
-      //       '이메일 혹은 비밀번호가 일치하지 않습니다. 입력한 내용을 다시 확인해 주세요.',
-      //     );
-      //   } else if (status === 403) {
-      //     setError('탈퇴한 계정입니다.');
-      //   } else if (status === 404) {
-      //     setError('사용자를 찾을 수 없습니다.');
-      //   } else {
-      //     setError('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      //   }
-      // } else {
-      //   setError('서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.');
-      // }
     }
   };
 

--- a/src/app/signup/components/SignUpForm.tsx
+++ b/src/app/signup/components/SignUpForm.tsx
@@ -7,6 +7,8 @@ import { FaRegEye, FaRegEyeSlash } from 'react-icons/fa';
 import { AuthTimer } from './AuthTimer';
 import handleApiErrorWithoutInterceptor from '@/utils/handleApiErrorWithoutInterceptor';
 
+const MAX_NICKNAME_LENGTH = 20;
+
 const SignUpForm = () => {
   const [email, setEmail] = useState('');
   const [authCode, setAuthCode] = useState('');
@@ -137,33 +139,6 @@ const SignUpForm = () => {
       }
     } catch (error: any) {
       handleApiErrorWithoutInterceptor(error, showEmailErrorAlert);
-      // if (error.response) {
-      //   const { status, data } = error.response;
-      //   console.log(`status: ${status}`);
-      //   const errorCode = data?.errorCode;
-      //   console.log(`errorRes: ${errorCode}`);
-
-      //   if (status === 400) {
-      //     if (errorCode === 'EMAIL_ALREADY_REGISTERED') {
-      //       setEmailMessage('이미 사용 중인 이메일입니다.');
-      //       setEmailMessageType('error');
-      //     } else {
-      //       setEmailMessage('잘못된 요청입니다. 다시 시도해주세요.');
-      //       setEmailMessageType('error');
-      //     }
-      //   } else if (status === 500 && errorCode === 'EMAIL_SEND_FAILED') {
-      //     setEmailMessage('인증번호 전송에 실패했습니다.');
-      //     setEmailMessageType('error');
-      //   } else {
-      //     setEmailMessage('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      //     setEmailMessageType('error');
-      //   }
-      // } else {
-      //   setEmailMessage(
-      //     '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',
-      //   );
-      //   setEmailMessageType('error');
-      // }
     }
   };
 
@@ -188,17 +163,6 @@ const SignUpForm = () => {
       }
     } catch (error: any) {
       handleApiErrorWithoutInterceptor(error, showAuthCodeErrorAlert);
-      // if (error.response) {
-      //   const { data } = error.response;
-      //   const message = data?.errorMessage;
-      //   setAuthCodeMessage(message);
-      //   setAuthCodeMessageType('error');
-      // } else {
-      //   setAuthCodeMessage(
-      //     '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',
-      //   );
-      //   setAuthCodeMessageType('error');
-      // }
     }
   };
 
@@ -209,12 +173,35 @@ const SignUpForm = () => {
     setAuthCodeMessageType('error');
   };
 
+  // 닉네임 길이 제한
+
   // 닉네임 중복 확인
   const handleNicknameAvailabilityCheckClick = async () => {
-    if (!nickname.trim()) {
-      setNicknameMessage('닉네임을 입력하세요.');
+    if (!nickname || nickname.trim().length === 0) {
+      setNicknameMessage('닉네임을 입력해 주세요.');
       setNicknameMessageType('error');
     }
+
+    // 닉네임 길이 검증 (2-20자)
+    if (nickname.length < 2) {
+      setNicknameMessage('닉네임은 최소 2자 이상이어야 합니다.');
+      setNicknameMessageType('error');
+      return;
+    }
+
+    if (nickname.length > MAX_NICKNAME_LENGTH) {
+      setNicknameMessage('닉네임은 최대 20자까지 입력 가능합니다.');
+      setNicknameMessageType('error');
+      return;
+    }
+
+    if (nickname === '탈퇴한 회원') {
+      setNicknameMessage('사용할 수 없는 닉네임입니다.');
+      setNicknameMessageType('error');
+      setNicknameAvailable(false);
+      return;
+    }
+
     try {
       const response = await axios.post(
         `${process.env.NEXT_PUBLIC_API_URL}/auth/check-nickname`,
@@ -229,29 +216,6 @@ const SignUpForm = () => {
       }
     } catch (error: any) {
       handleApiErrorWithoutInterceptor(error, showNickNameAlert);
-      // if (error.response) {
-      //   const { status, data } = error.response;
-      //   const errorCode = data?.errorCode;
-
-      //   if (status === 400) {
-      //     if (errorCode === 'NICKNAME_ALREADY_REGISTERED') {
-      //       setNicknameMessage('이미 사용 중인 닉네임입니다.');
-      //       setNicknameMessageType('error');
-      //       setNicknameAvailable(false);
-      //     } else {
-      //       setNicknameMessage('잘못된 요청입니다. 다시 시도해주세요.');
-      //       setNicknameMessageType('error');
-      //     }
-      //   } else {
-      //     setNicknameMessage('오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      //     setNicknameMessageType('error');
-      //   }
-      // } else {
-      //   setNicknameMessage(
-      //     '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',
-      //   );
-      //   setNicknameMessageType('error');
-      // }
     }
   };
 
@@ -297,15 +261,29 @@ const SignUpForm = () => {
       return;
     }
 
-    if (!nickname.trim()) {
+    if (!nickname || nickname.trim().length === 0) {
       setNicknameMessage('닉네임을 입력해 주세요.');
       setNicknameMessageType('error');
+      return;
+    } else if (nickname.length < 2) {
+      setNicknameMessage('닉네임은 최소 2자 이상이어야 합니다.');
+      setNicknameMessageType('error');
+      return;
+    } else if (nickname.length > MAX_NICKNAME_LENGTH) {
+      setNicknameMessage('닉네임은 최대 20자까지 입력 가능합니다.');
+      setNicknameMessageType('error');
+      return;
+    } else if (nickname === '탈퇴한 회원') {
+      setNicknameMessage('사용할 수 없는 닉네임입니다.');
+      setNicknameMessageType('error');
+      setNicknameAvailable(false);
       return;
     } else if (!nicknameAvailable) {
       setNicknameMessage('닉네임 중복 확인을 완료해 주세요.');
       setNicknameMessageType('error');
       return;
     }
+
     if (!isValidPassword(password)) {
       setPasswordError(
         '비밀번호는 최소 8자 이상이며, 하나 이상의 영문자, 숫자, 특수문자가 포함되어야 합니다.',

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -334,10 +334,12 @@ const Header = () => {
       </div>
 
       <div className="navbar-end hidden lg:flex space-x-2">
-        <NotificationButton
-          count={notificationCount}
-          onClick={toggleNotificationModal}
-        />
+        {isSignedIn && (
+          <NotificationButton
+            count={notificationCount}
+            onClick={toggleNotificationModal}
+          />
+        )}
         <AuthLinks
           isSignedIn={isSignedIn}
           userInfo={userInfo}
@@ -351,10 +353,12 @@ const Header = () => {
 
       {/* 모바일 네브바 */}
       <div className="navbar-end lg:hidden">
-        <NotificationButton
-          count={notificationCount}
-          onClick={toggleNotificationModal}
-        />
+        {isSignedIn && (
+          <NotificationButton
+            count={notificationCount}
+            onClick={toggleNotificationModal}
+          />
+        )}
         <button
           className="btn btn-ghost"
           onClick={toggleNav}

--- a/src/hooks/useGroupChat.ts
+++ b/src/hooks/useGroupChat.ts
@@ -16,7 +16,7 @@ interface ChatMessage {
   chatRoomId: number;
   content: string;
   createdAt: string;
-  timestamp: string;
+  // timestamp: string;
   user: User;
 }
 
@@ -65,7 +65,7 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
       return {
         messages: content.map((msg: ChatMessage) => ({
           ...msg,
-          timestamp: msg.createdAt,
+          createdAt: msg.createdAt,
         })),
         page: pageable.pageNumber,
         hasNextPage: hasMorePages,
@@ -161,7 +161,7 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
           onConnect: () => {
             client.subscribe(`/topic/chat/${chatRoomId}`, messageOutput => {
               const newMessage = JSON.parse(messageOutput.body) as ChatMessage;
-              newMessage.timestamp = newMessage.createdAt;
+              newMessage.createdAt = newMessage.createdAt;
               // addNewMessage(newMessage);
               // 현재 캐시된 데이터 확인
               console.log('보낸 메시지', newMessage);
@@ -273,7 +273,7 @@ export const useGroupChat = ({ chatRoomId, userId }: UseGroupChatParams) => {
   const uniqueMessages = Array.from(
     new Map(messages.map(m => [m.id, m])).values(),
   ).sort(
-    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
   );
 
   return {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 닉네임
  - 닉네임 검증 구현하지 않음
- 알림 버튼
  - 로그인 상태에 관계없이 알림 버튼 표시
- 채팅
  - 서버에서 createdAt으로 넘어오면 timestamp로 수정

**TO-BE**
- 닉네임
  - 닉네임 길이 제한(2자-20자) 및 사용불가 닉네임(e.g. 탈퇴한 회원) 검증 추가
- 알림 버튼
  - 로그인 상태(`isSignedIn`)가 true인 경우에만 알림 버튼 표시
- 채팅
  - createdAt으로 통합하여 헷갈림 방지
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [ ] 닉네임 설정 및 변경에서 검증 로직 적용 테스트
- [ ] 로그인 상태에 따른 알림 버튼 표시 테스트