### PR TITLE
refactor: 웹소켓 연결 및 알림&채팅 구독 로직 개선, NotificationModal 리팩토링 / fix: 빌드 에러 해결

### DIFF
--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -132,7 +132,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
   const { userInfo } = useAuthStore();
   const userId = userInfo?.id || 111;
   const chatContainerRef = useRef<HTMLDivElement>(null);
-  const isConnecting = useRef(false);
   const isInitialLoad = useRef(true);
   const isLoadingPrevMessages = useRef(false);
   const lastMessageLength = useRef(0);
@@ -149,8 +148,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
     hasNextPage,
     isFetchingNextPage,
     sendMessage,
-    chatState,
-    connect,
   } = useGroupChat({ chatRoomId, userId });
 
   // Intersection Observer 설정
@@ -250,23 +247,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
       setShowAlert(true); // 전역적인 알림 표시 등으로 대체
     }
   };
-
-  if (chatState.error) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-4">
-        <div className="alert alert-error">
-          <span>{chatState.error}</span>
-        </div>
-        <button
-          onClick={connect}
-          disabled={isConnecting.current}
-          className="btn bg-teal-500"
-        >
-          {isConnecting.current ? '연결 중...' : '채팅방 재연결'}
-        </button>
-      </div>
-    );
-  }
 
   return (
     <div className="flex justify-center items-start h-[screen]">

--- a/src/app/community/study/write/components/StudyWriteForm.tsx
+++ b/src/app/community/study/write/components/StudyWriteForm.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { MEETING_TYPE } from '@/types/study';
 import OnlineForm from './OnlineForm';
 import HybridForm from './HybridForm';
-import { MEETING_TYPE } from '@/types/study';
 
 type StudyType = 'ONLINE' | 'HYBRID';
 

--- a/src/app/oauth2/callback/components/KakaoCallbackClient.tsx
+++ b/src/app/oauth2/callback/components/KakaoCallbackClient.tsx
@@ -51,25 +51,6 @@ const KakaoCallbackClient = () => {
         }
       } catch (error: any) {
         handleApiErrorWithoutInterceptor(error, showErrorAlert);
-
-        // if (error) {
-        //   const { status, errorMessage, errorCode } = error;
-
-        //   if (status === 500 && errorCode === 'INTERNAL_SERVER_ERROR') {
-        //     setAlertMessage(errorMessage);
-        //     setShowAlert(true);
-        //   } else {
-        //     setAlertMessage(
-        //       '카카오 로그인에 실패했습니다. 다시 시도해 주세요.',
-        //     );
-        //     setShowAlert(true);
-        //   }
-        // } else {
-        //   setAlertMessage(
-        //     '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',
-        //   );
-        //   setShowAlert(true);
-        // }
       }
     };
 

--- a/src/components/layout/Header/NotificationItem.tsx
+++ b/src/components/layout/Header/NotificationItem.tsx
@@ -1,0 +1,54 @@
+'use client';
+import React from 'react';
+import {
+  getNotificationMessage,
+  calculateTimeDifference,
+} from './NotificationMessage';
+import { Notification } from '@/types/notification';
+
+export interface NotificationItemProps {
+  notification: Notification;
+  serverTime: string | null;
+  onDelete: (notificationId: number, e: React.MouseEvent) => void;
+  onClick: (notificationId: number) => void;
+  isLast?: boolean;
+  lastItemRef?: (node?: Element | null) => void;
+}
+
+const NotificationItem: React.FC<NotificationItemProps> = ({
+  notification,
+  serverTime,
+  onDelete,
+  onClick,
+  isLast,
+  lastItemRef,
+}) => {
+  return (
+    <li
+      ref={isLast ? lastItemRef : null}
+      onClick={() => onClick(notification.id)}
+      className={`p-3 border-b border-gray-200 cursor-pointer hover:bg-gray-200 ${
+        notification.read
+          ? 'bg-gray-100 text-gray-700 opacity-70'
+          : 'text-gray-800'
+      }`}
+    >
+      <div>{getNotificationMessage(notification)}</div>
+      <div className="flex justify-between items-center mt-2">
+        <div className="text-gray-500 text-sm text-right">
+          {serverTime
+            ? calculateTimeDifference(notification.createdAt, serverTime)
+            : '로딩 중...'}
+        </div>
+        <button
+          onClick={e => onDelete(notification.id, e)}
+          className="text-sm text-red-500 hover:text-red-700"
+        >
+          삭제
+        </button>
+      </div>
+    </li>
+  );
+};
+
+export default NotificationItem;

--- a/src/components/layout/Header/NotificationMessage.tsx
+++ b/src/components/layout/Header/NotificationMessage.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { NOTIFICATION_MESSAGES, Notification } from '@/types/notification';
+import { ReactNode } from 'react';
+
+export const getNotificationMessage = (
+  notification: Notification,
+): ReactNode => {
+  if (notification.type in NOTIFICATION_MESSAGES) {
+    const messageConfig = NOTIFICATION_MESSAGES[notification.type];
+    return (
+      <>
+        <span>
+          [{messageConfig.icon} {messageConfig.prefix}]{' '}
+        </span>
+        <strong>{notification.sender.nickname}</strong>{' '}
+        <span
+          dangerouslySetInnerHTML={{
+            __html: messageConfig.getMessage(notification),
+          }}
+        />
+      </>
+    );
+  }
+
+  return '알 수 없는 알림 유형입니다.';
+};
+
+// 시간 차이를 계산하는 함수
+export const calculateTimeDifference = (
+  createdAt: string,
+  serverTime: string,
+) => {
+  const serverDate = new Date(serverTime);
+  const createdDate = new Date(createdAt);
+
+  const diffInSeconds = Math.floor(
+    (serverDate.getTime() - createdDate.getTime()) / 1000,
+  );
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  const diffInDays = Math.floor(diffInHours / 24);
+  const diffInMonths = Math.floor(diffInDays / 30);
+  const diffInYears = Math.floor(diffInDays / 365);
+
+  if (diffInYears >= 1) return `${diffInYears}년 전`;
+  if (diffInMonths >= 1) return `${diffInMonths}개월 전`;
+  if (diffInDays >= 1) return `${diffInDays}일 전`;
+  if (diffInHours >= 1) return `${diffInHours}시간 전`;
+  if (diffInMinutes >= 1) return `${diffInMinutes}분 전`;
+  return '방금 전';
+};

--- a/src/components/layout/Header/NotificationModal.tsx
+++ b/src/components/layout/Header/NotificationModal.tsx
@@ -1,72 +1,17 @@
+'use client';
+
 import CustomAlert from '@/components/common/Alert';
 import CustomConfirm from '@/components/common/Confirm';
 import { useAuthStore } from '@/store/authStore';
-import { User } from '@/types/post';
 import axiosInstance from '@/utils/axios';
 import handleApiError from '@/utils/handleApiError';
 import axios from 'axios';
-import { ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FaCheck, FaTrashAlt } from 'react-icons/fa';
 import { useRouter } from 'next/navigation';
 import { useInView } from 'react-intersection-observer';
-
-export type Notification = {
-  id: number;
-  userId: number;
-  sender: User;
-  type: string;
-  createdAt: string;
-  postType: string;
-  postTitle: string | null;
-  postContent: string | null;
-  commentContent: string | null;
-  replyContent: string | null;
-  studyName: string | null;
-  targetId: number;
-  read: boolean;
-};
-
-type NotificationModalProps = {
-  notifications: Notification[];
-  onUpdateNotifications: (notifications: Notification[]) => void;
-  hasNextPage?: boolean;
-  fetchNextPage: () => void;
-  isFetchingNextPage?: boolean;
-  onClose: () => void;
-};
-
-// 시간 차이를 계산하는 함수
-const calculateTimeDifference = (createdAt: string, serverTime: string) => {
-  const serverDate = new Date(serverTime); // 서버 시간 UTC -> KST 변환
-  const createdDate = new Date(createdAt); // 알림 시간 (이미 KST)
-
-  const diffInSeconds = Math.floor(
-    (serverDate.getTime() - createdDate.getTime()) / 1000,
-  );
-  const diffInMinutes = Math.floor(diffInSeconds / 60);
-  const diffInHours = Math.floor(diffInMinutes / 60);
-  const diffInDays = Math.floor(diffInHours / 24);
-  const diffInMonths = Math.floor(diffInDays / 30);
-  const diffInYears = Math.floor(diffInDays / 365);
-
-  // 차이 계산 후 결과 반환
-  if (diffInYears >= 1) {
-    return `${diffInYears}년 전`;
-  }
-  if (diffInMonths >= 1) {
-    return `${diffInMonths}개월 전`;
-  }
-  if (diffInDays >= 1) {
-    return `${diffInDays}일 전`;
-  }
-  if (diffInHours >= 1) {
-    return `${diffInHours}시간 전`;
-  }
-  if (diffInMinutes >= 1) {
-    return `${diffInMinutes}분 전`;
-  }
-  return '방금 전';
-};
+import NotificationItem from './NotificationItem';
+import { NotificationModalProps } from '@/types/notification';
 
 const NotificationModal = ({
   notifications,
@@ -122,7 +67,6 @@ const NotificationModal = ({
         );
         if (response.status === 200) {
         }
-        console.log('현재 시간은', response.data.currentTime);
         setServerTime(response.data.currentTime);
       } catch (error) {
         console.error('서버 시간을 가져오는 데 실패하였습니다.', error);
@@ -338,131 +282,17 @@ const NotificationModal = ({
                       new Date(b.createdAt).getTime() -
                       new Date(a.createdAt).getTime(),
                   )
-                  .map((notification, index) => {
-                    let message: ReactNode = '';
-
-                    switch (notification.type) {
-                      case 'COMMENT_ADDED':
-                        message = (
-                          <>
-                            [🔔 댓글]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.postTitle}
-                            </strong>{' '}
-                            게시글에 댓글을 남겼습니다.
-                          </>
-                        );
-                        break;
-                      case 'REPLY_ADDED':
-                        message = (
-                          <>
-                            [🔔 답글]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이 당신의 댓글에 답글을 남겼습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_SIGNUP_ADDED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디 신청 요청을 보냈습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_SIGNUP_APPROVED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디 신청을 수락했습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_SIGNUP_REJECTED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디 신청을 거절했습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_CREATED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디를 개설했습니다. 마이페이지에서 채팅 및
-                            스터디룸 이용이 가능합니다!
-                          </>
-                        );
-                        break;
-                    }
-                    return (
-                      <li
-                        key={notification.id}
-                        onClick={() => handleNotificationClick(notification.id)}
-                        className={`p-3 border-b border-gray-200 cursor-pointer hover:bg-gray-200 ${notification.read ? 'bg-gray-100 text-gray-700 opacity-70' : 'text-gray-800'}`}
-                        ref={
-                          index === notifications.length - 1
-                            ? infiniteScrollRef
-                            : null
-                        }
-                      >
-                        {message}
-                        <div className="flex justify-between items-center mt-2">
-                          <div className="text-gray-500 text-sm text-right">
-                            {serverTime
-                              ? calculateTimeDifference(
-                                  notification.createdAt,
-                                  serverTime,
-                                )
-                              : '로딩 중...'}
-                          </div>
-                          <button
-                            onClick={e =>
-                              handleNotificationDeleteClick(notification.id, e)
-                            }
-                            className="text-sm text-red-500 hover:text-red-700"
-                          >
-                            삭제
-                          </button>
-                        </div>
-                      </li>
-                    );
-                  })}
+                  .map((notification, index) => (
+                    <NotificationItem
+                      key={notification.id}
+                      notification={notification}
+                      serverTime={serverTime}
+                      onClick={handleNotificationClick}
+                      onDelete={handleNotificationDeleteClick}
+                      isLast={index === notifications.length - 1}
+                      lastItemRef={infiniteScrollRef}
+                    />
+                  ))}
               </ul>
               {isFetchingNextPage && (
                 <div className="text-center py-4 text-gray-500">

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -11,8 +11,10 @@ import CustomAlert from '@/components/common/Alert';
 import { FiBell } from 'react-icons/fi';
 import axiosInstance from '@/utils/axios';
 import handleApiError from '@/utils/handleApiError';
-import NotificationModal, { Notification } from './NotificationModal';
+import NotificationModal from './NotificationModal';
 import useNotification from '@/hooks/useNotification';
+import useWebSocket from '@/hooks/useWebSocket';
+import { Notification } from '@/types/notification';
 
 type NavigationItem = {
   path: string;
@@ -222,9 +224,8 @@ const Header = () => {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    connect,
-    disconnect,
   } = useNotification(userId || 0);
+  const { connect, disconnect } = useWebSocket(userId || 0);
   const { notifications }: { notifications: Notification[] } = useNotification(
     userId || 0,
   );

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Client, StompSubscription } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+interface WebSocketState {
+  isConnected: boolean;
+  error: string | null;
+}
+
+const useWebSocket = (
+  userId: number,
+  // onMessageReceived: (message: any) => void,
+) => {
+  const stompClient = useRef<Client | null>(null);
+  const subscriptions = useRef<Map<string, StompSubscription>>(new Map());
+  const isConnecting = useRef<boolean>(false);
+  const [webSocketState, setWebSocketState] = useState<WebSocketState>({
+    isConnected: false,
+    error: null,
+  });
+  // const [, setIsConnected] = useState(false);
+
+  // WebSocket 연결 함수
+  const connect = useCallback(() => {
+    if (!userId || isConnecting.current || stompClient.current?.connected)
+      return;
+
+    isConnecting.current = true;
+
+    const socket = new SockJS(
+      `${process.env.NEXT_PUBLIC_CHAT_SOCKET_URL}/ws` as string,
+    );
+
+    if (stompClient.current) {
+      stompClient.current.deactivate();
+      stompClient.current = null;
+    }
+
+    const client = new Client({
+      webSocketFactory: () => socket,
+      reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000,
+      onConnect: () => {
+        isConnecting.current = false;
+        setWebSocketState({ isConnected: true, error: null });
+        console.log('알림 WebSocket 연결 성공');
+        // client.subscribe(`/topic/notifications/${userId}`, message => {
+        //   try {
+        //     const parsedMessage = JSON.parse(message.body);
+        //     onMessageReceived(parsedMessage);
+        //   } catch (error) {
+        //     console.error('알림 메시지 파싱 오류:', error);
+        //   }
+        // });
+      },
+      onDisconnect: () => {
+        isConnecting.current = false;
+        setWebSocketState(prev => ({ ...prev, isConnected: false }));
+        console.log('알림 WebSocket 연결 해제됨');
+      },
+      onStompError: error => {
+        isConnecting.current = false;
+        setWebSocketState(prev => ({
+          ...prev,
+          error: error.headers?.message || '연결 오류가 발생했습니다.',
+        }));
+        console.error('WebSocket 오류:', error);
+      },
+    });
+
+    stompClient.current = client;
+    client.activate();
+  }, [userId]);
+
+  // 토픽 구독 함수
+  const subscribe = useCallback(
+    (topic: string, callback: (message: any) => void) => {
+      if (!stompClient.current?.connected) {
+        throw new Error('WebSocket이 연결되어 있지 않습니다.');
+      }
+
+      if (!subscriptions.current.has(topic)) {
+        const subscription = stompClient.current.subscribe(topic, message => {
+          try {
+            const parsedMessage = JSON.parse(message.body);
+            callback(parsedMessage);
+          } catch (error) {
+            console.error('메시지 파싱 오류:', error);
+          }
+        });
+        subscriptions.current.set(topic, subscription);
+        console.log(`${topic} 구독 성공`);
+      }
+    },
+    [],
+  );
+
+  // 토픽 구독 해제 함수
+  const unsubscribe = useCallback((topic: string) => {
+    const subscription = subscriptions.current.get(topic);
+    if (subscription) {
+      subscription.unsubscribe();
+      subscriptions.current.delete(topic);
+      console.log(`${topic} 구독 취소`);
+    }
+  }, []);
+
+  // WebSocket 연결 해제 함수
+  const disconnect = useCallback(() => {
+    // 모든 구독 취소
+    subscriptions.current.forEach(subscription => {
+      subscription.unsubscribe();
+    });
+    subscriptions.current.clear();
+
+    if (stompClient.current?.connected) {
+      stompClient.current.deactivate();
+      stompClient.current = null;
+      setWebSocketState({ isConnected: false, error: null });
+    }
+  }, []);
+
+  // 웹소켓 publish 함수(채팅)
+  const publish = useCallback((destination: string, body: string) => {
+    if (!stompClient.current?.connected) {
+      throw new Error('WebSocket이 연결되어 있지 않습니다.');
+    }
+
+    stompClient.current.publish({
+      destination,
+      body,
+    });
+  }, []);
+
+  // WebSocket 연결 관리
+  useEffect(() => {
+    if (userId) connect();
+    return () => disconnect();
+  }, [userId, connect, disconnect]);
+
+  return {
+    webSocketState,
+    subscribe,
+    unsubscribe,
+    publish,
+    connect,
+    disconnect,
+  };
+};
+
+export default useWebSocket;

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,99 @@
+import { User } from './post';
+
+export type Notification = {
+  id: number;
+  userId: number;
+  sender: User;
+  type: NotificationType;
+  createdAt: string;
+  postType: string;
+  postTitle: string | null;
+  postContent: string | null;
+  commentContent: string | null;
+  replyContent: string | null;
+  studyName: string | null;
+  targetId: number;
+  read: boolean;
+};
+
+export enum PostType {
+  STUDY = 'STUDY',
+  INFO = 'INFO',
+  QNA = 'QNA',
+}
+
+export type NotificationModalProps = {
+  notifications: Notification[];
+  onUpdateNotifications: (notifications: Notification[]) => void;
+  hasNextPage?: boolean;
+  fetchNextPage: () => void;
+  isFetchingNextPage?: boolean;
+  onClose: () => void;
+};
+
+export interface NotificationContent {
+  postTitle?: string | null;
+  postContent?: string | null;
+  commentContent?: string | null;
+  replyContent?: string | null;
+  studyName?: string | null;
+}
+
+export const NotificationType = {
+  COMMENT_ADDED: 'COMMENT_ADDED',
+  REPLY_ADDED: 'REPLY_ADDED',
+  STUDY_SIGNUP_ADDED: 'STUDY_SIGNUP_ADDED',
+  STUDY_SIGNUP_APPROVED: 'STUDY_SIGNUP_APPROVED',
+  STUDY_SIGNUP_REJECTED: 'STUDY_SIGNUP_REJECTED',
+  STUDY_CREATED: 'STUDY_CREATED',
+} as const;
+
+type NotificationType =
+  (typeof NotificationType)[keyof typeof NotificationType];
+
+export interface NotificationMessage {
+  icon: string;
+  prefix: string;
+  getMessage: (notification: Notification) => string;
+}
+
+export const NOTIFICATION_MESSAGES: Record<
+  NotificationType,
+  NotificationMessage
+> = {
+  [NotificationType.COMMENT_ADDED]: {
+    icon: '🔔',
+    prefix: '댓글',
+    getMessage: notification =>
+      `님이 <strong>${notification.postTitle}</strong> 게시글에 댓글을 남겼습니다.`,
+  },
+  [NotificationType.REPLY_ADDED]: {
+    icon: '🔔',
+    prefix: '답글',
+    getMessage: () => '님이 당신의 댓글에 답글을 남겼습니다.',
+  },
+  [NotificationType.STUDY_SIGNUP_ADDED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디 신청 요청을 보냈습니다.`,
+  },
+  [NotificationType.STUDY_SIGNUP_APPROVED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디 신청을 수락했습니다.`,
+  },
+  [NotificationType.STUDY_SIGNUP_REJECTED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디 신청을 거절했습니다.`,
+  },
+  [NotificationType.STUDY_CREATED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디를 개설했습니다. 마이페이지에서 채팅 및 스터디룸 이용이 가능합니다!`,
+  },
+};


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 웹소켓 연결
  - 알림 기능과 채팅 기능에서 각각 웹소켓 연결 구현
- 알림
  - NotificationModal.tsx 파일 안에 모든 코드 작성
- 채팅
    - 채팅방 입장 시 웹소켓 연결 후 채팅 토픽 구독, 채팅방 퇴장 시 웹소켓 연결 끊김
- 빌드 에러
  - npm run build 실행 시 _not-found 페이지에서 ReferenceError 발생

**TO-BE**
- 웹소켓 연결
  - useWebSocket.ts 훅 함수파일을 만들어 로그인 시에 웹소켓 연결하여 단일 웹소켓 연결 유지
- 알림
  - 로그인 상태일때는 항상 알림 토픽 구독 상태
  - NotificationMessage, NotificationItem, NotificationModal 컴포넌트 분리
  - Notification.ts 파일에서 notification 관련 타입 관리
- 채팅
  - 채팅방 입장 시 채팅 토픽 구독, 퇴장 시 채팅 토픽 구독 해제
  - 채팅 메시지 전송 시 useWebSocket.ts 파일의 publish 함수 이용하여 메시지 발행
- 빌드 에러
  - 타입 참조 순서가 꼬이지 않도록 코드 구조 재정리(타입 정의 → 인터페이스 정의 → 상수 및 함수 정의)
  - Notification.ts 파일을 만들어 파일 내에서 타입 관리

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] npm run build 테스트
- [X] 웹소켓 연결 및 토픽 구독, 발행 테스트