### PR TITLE
merge: 알림창 무한스크롤 구현, 웹소켓 연결 및 알림&채팅 구독 로직 개선 후 main 브랜치로 통합

### DIFF
--- a/src/app/api/info-posts/[id]/route.ts
+++ b/src/app/api/info-posts/[id]/route.ts
@@ -51,7 +51,11 @@ export async function POST(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   try {
     const id = request.nextUrl.pathname.split('/')[3];
-    await axios.delete(`${process.env.API_BASE_URL}/info-posts/${id}`);
+    await axios.delete(`${process.env.API_URL}/info-posts/${id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
     return NextResponse.json({ message: '게시글이 삭제되었습니다.' });
   } catch (error) {
     console.error('게시글 삭제 실패:', error);

--- a/src/app/chat/components/ChatRoom.tsx
+++ b/src/app/chat/components/ChatRoom.tsx
@@ -132,7 +132,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
   const { userInfo } = useAuthStore();
   const userId = userInfo?.id || 111;
   const chatContainerRef = useRef<HTMLDivElement>(null);
-  const isConnecting = useRef(false);
   const isInitialLoad = useRef(true);
   const isLoadingPrevMessages = useRef(false);
   const lastMessageLength = useRef(0);
@@ -149,8 +148,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
     hasNextPage,
     isFetchingNextPage,
     sendMessage,
-    chatState,
-    connect,
   } = useGroupChat({ chatRoomId, userId });
 
   // Intersection Observer 설정
@@ -250,23 +247,6 @@ const ChatRoom = ({ chatRoomId }: ChatRoomProps) => {
       setShowAlert(true); // 전역적인 알림 표시 등으로 대체
     }
   };
-
-  if (chatState.error) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-4">
-        <div className="alert alert-error">
-          <span>{chatState.error}</span>
-        </div>
-        <button
-          onClick={connect}
-          disabled={isConnecting.current}
-          className="btn bg-teal-500"
-        >
-          {isConnecting.current ? '연결 중...' : '채팅방 재연결'}
-        </button>
-      </div>
-    );
-  }
 
   return (
     <div className="flex justify-center items-start h-[screen]">

--- a/src/app/community/components/InfoDetailContent.tsx
+++ b/src/app/community/components/InfoDetailContent.tsx
@@ -43,7 +43,7 @@ export default function InfoDetailContent({ postId }: InfoDetailContentProps) {
     if (window.confirm('정말로 삭제하시겠습니까?')) {
       try {
         await axios.delete(
-          `${process.env.NEXT_PUBLIC_API_URL}/info-posts/${postId}`,
+          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/info-posts/${postId}`,
         );
         await queryClient.invalidateQueries({ queryKey: ['info-posts'] });
         setAlertMessage('게시글이 삭제되었습니다.');

--- a/src/app/community/components/QnADetailContent.tsx
+++ b/src/app/community/components/QnADetailContent.tsx
@@ -43,7 +43,7 @@ export default function QnADetailContent({ postId }: QnADetailContentProps) {
     if (window.confirm('정말로 삭제하시겠습니까?')) {
       try {
         await axios.delete(
-          `${process.env.NEXT_PUBLIC_API_URL}/qna-posts/${postId}`,
+          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/qna-posts/${postId}`,
         );
         await queryClient.invalidateQueries({ queryKey: ['qna-posts'] });
         setAlertMessage('게시글이 삭제되었습니다.');

--- a/src/app/community/study/write/components/StudyWriteForm.tsx
+++ b/src/app/community/study/write/components/StudyWriteForm.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { MEETING_TYPE } from '@/types/study';
 import OnlineForm from './OnlineForm';
 import HybridForm from './HybridForm';
-import { MEETING_TYPE } from '@/types/study';
 
 type StudyType = 'ONLINE' | 'HYBRID';
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import Providers from '@/providers/tanstack-query/Providers';
 
 export const metadata: Metadata = {
   title: 'DevOnOff',
-  description: '개발자 온오프라인 스터디 플랫폼',
+  description: '온오프라인 개발 스터디 플랫폼',
 };
 
 export default async function RootLayout({

--- a/src/app/oauth2/callback/components/KakaoCallbackClient.tsx
+++ b/src/app/oauth2/callback/components/KakaoCallbackClient.tsx
@@ -51,25 +51,6 @@ const KakaoCallbackClient = () => {
         }
       } catch (error: any) {
         handleApiErrorWithoutInterceptor(error, showErrorAlert);
-
-        // if (error) {
-        //   const { status, errorMessage, errorCode } = error;
-
-        //   if (status === 500 && errorCode === 'INTERNAL_SERVER_ERROR') {
-        //     setAlertMessage(errorMessage);
-        //     setShowAlert(true);
-        //   } else {
-        //     setAlertMessage(
-        //       '카카오 로그인에 실패했습니다. 다시 시도해 주세요.',
-        //     );
-        //     setShowAlert(true);
-        //   }
-        // } else {
-        //   setAlertMessage(
-        //     '서버에 연결할 수 없습니다. 네트워크 상태를 확인해 주세요.',
-        //   );
-        //   setShowAlert(true);
-        // }
       }
     };
 

--- a/src/app/signup/components/SignUpForm.tsx
+++ b/src/app/signup/components/SignUpForm.tsx
@@ -383,7 +383,12 @@ const SignUpForm = () => {
                 id="authCode"
                 type="text"
                 value={authCode}
-                onChange={e => setAuthCode(e.target.value.trim())}
+                onChange={e => {
+                  setAuthCode(e.target.value.trim());
+                  setAuthCodeVerified(false); // 인증 번호 수정 시 인증 상태 초기화
+                  setAuthCodeMessage(''); // 메시지 초기화
+                  setAuthCodeMessageType('');
+                }}
                 required
                 className="w-full flex-grow input input-bordered px-4 py-2 focus:outline-teal-500 text-sm sm:text-base"
               />

--- a/src/app/studyroom/components/VideoRoomComponents.tsx
+++ b/src/app/studyroom/components/VideoRoomComponents.tsx
@@ -586,8 +586,8 @@ export default function VideoRoomComponent() {
           onClick={toggleAudio}
           className={`px-4 py-2 rounded transition-colors ${
             isAudioEnabled
-              ? 'bg-teal-500 hover:bg-gray-400 text-white'
-              : 'bg-gray-400 hover:bg-teal-500 text-white'
+              ? 'bg-teal-500 hover:bg-teal-600 text-white'
+              : 'bg-gray-400 hover:bg-gray-500 text-white'
           } flex items-center justify-center`}
         >
           {isAudioEnabled ? (
@@ -601,8 +601,8 @@ export default function VideoRoomComponent() {
           onClick={toggleVideo}
           className={`px-4 py-2 rounded transition-colors ${
             isVideoEnabled
-              ? 'bg-teal-500 hover:bg-gray-400 text-white'
-              : 'bg-gray-400 hover:bg-teal-500 text-white'
+              ? 'bg-teal-500 hover:bg-teal-600 text-white'
+              : 'bg-gray-400 hover:bg-gray-500 text-white'
           } flex items-center justify-center`}
         >
           {isVideoEnabled ? (
@@ -616,8 +616,8 @@ export default function VideoRoomComponent() {
           onClick={toggleScreenShare}
           className={`px-4 py-2 rounded transition-colors ${
             isScreenSharing
-              ? 'bg-teal-500 hover:bg-gray-400 text-white'
-              : 'bg-gray-400 hover:bg-teal-500 text-white'
+              ? 'bg-teal-500 hover:bg-teal-600 text-white'
+              : 'bg-gray-400 hover:bg-gray-500 text-white'
           } flex items-center justify-center`}
         >
           {isScreenSharing ? (

--- a/src/components/layout/Header/NotificationItem.tsx
+++ b/src/components/layout/Header/NotificationItem.tsx
@@ -1,0 +1,54 @@
+'use client';
+import React from 'react';
+import {
+  getNotificationMessage,
+  calculateTimeDifference,
+} from './NotificationMessage';
+import { Notification } from '@/types/notification';
+
+export interface NotificationItemProps {
+  notification: Notification;
+  serverTime: string | null;
+  onDelete: (notificationId: number, e: React.MouseEvent) => void;
+  onClick: (notificationId: number) => void;
+  isLast?: boolean;
+  lastItemRef?: (node?: Element | null) => void;
+}
+
+const NotificationItem: React.FC<NotificationItemProps> = ({
+  notification,
+  serverTime,
+  onDelete,
+  onClick,
+  isLast,
+  lastItemRef,
+}) => {
+  return (
+    <li
+      ref={isLast ? lastItemRef : null}
+      onClick={() => onClick(notification.id)}
+      className={`p-3 border-b border-gray-200 cursor-pointer hover:bg-gray-200 ${
+        notification.read
+          ? 'bg-gray-100 text-gray-700 opacity-70'
+          : 'text-gray-800'
+      }`}
+    >
+      <div>{getNotificationMessage(notification)}</div>
+      <div className="flex justify-between items-center mt-2">
+        <div className="text-gray-500 text-sm text-right">
+          {serverTime
+            ? calculateTimeDifference(notification.createdAt, serverTime)
+            : '로딩 중...'}
+        </div>
+        <button
+          onClick={e => onDelete(notification.id, e)}
+          className="text-sm text-red-500 hover:text-red-700"
+        >
+          삭제
+        </button>
+      </div>
+    </li>
+  );
+};
+
+export default NotificationItem;

--- a/src/components/layout/Header/NotificationMessage.tsx
+++ b/src/components/layout/Header/NotificationMessage.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { NOTIFICATION_MESSAGES, Notification } from '@/types/notification';
+import { ReactNode } from 'react';
+
+export const getNotificationMessage = (
+  notification: Notification,
+): ReactNode => {
+  if (notification.type in NOTIFICATION_MESSAGES) {
+    const messageConfig = NOTIFICATION_MESSAGES[notification.type];
+    return (
+      <>
+        <span>
+          [{messageConfig.icon} {messageConfig.prefix}]{' '}
+        </span>
+        <strong>{notification.sender.nickname}</strong>{' '}
+        <span
+          dangerouslySetInnerHTML={{
+            __html: messageConfig.getMessage(notification),
+          }}
+        />
+      </>
+    );
+  }
+
+  return '알 수 없는 알림 유형입니다.';
+};
+
+// 시간 차이를 계산하는 함수
+export const calculateTimeDifference = (
+  createdAt: string,
+  serverTime: string,
+) => {
+  const serverDate = new Date(serverTime);
+  const createdDate = new Date(createdAt);
+
+  const diffInSeconds = Math.floor(
+    (serverDate.getTime() - createdDate.getTime()) / 1000,
+  );
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  const diffInDays = Math.floor(diffInHours / 24);
+  const diffInMonths = Math.floor(diffInDays / 30);
+  const diffInYears = Math.floor(diffInDays / 365);
+
+  if (diffInYears >= 1) return `${diffInYears}년 전`;
+  if (diffInMonths >= 1) return `${diffInMonths}개월 전`;
+  if (diffInDays >= 1) return `${diffInDays}일 전`;
+  if (diffInHours >= 1) return `${diffInHours}시간 전`;
+  if (diffInMinutes >= 1) return `${diffInMinutes}분 전`;
+  return '방금 전';
+};

--- a/src/components/layout/Header/NotificationModal.tsx
+++ b/src/components/layout/Header/NotificationModal.tsx
@@ -8,6 +8,7 @@ import axios from 'axios';
 import { ReactNode, useEffect, useState } from 'react';
 import { FaCheck, FaTrashAlt } from 'react-icons/fa';
 import { useRouter } from 'next/navigation';
+import { useInView } from 'react-intersection-observer';
 
 export type Notification = {
   id: number;
@@ -27,11 +28,11 @@ export type Notification = {
 
 type NotificationModalProps = {
   notifications: Notification[];
-  setNotifications: (notifications: Notification[]) => void;
-  setNotificationCount: (notificationCount: number) => void;
-  onDeleteNotification: (updatedNotifications: Notification[]) => void;
+  onUpdateNotifications: (notifications: Notification[]) => void;
+  hasNextPage?: boolean;
+  fetchNextPage: () => void;
+  isFetchingNextPage?: boolean;
   onClose: () => void;
-  // onAllMessagesRead: () => void
 };
 
 // 시간 차이를 계산하는 함수
@@ -69,16 +70,15 @@ const calculateTimeDifference = (createdAt: string, serverTime: string) => {
 
 const NotificationModal = ({
   notifications,
-  setNotifications,
+  onUpdateNotifications,
+  hasNextPage,
+  fetchNextPage,
+  isFetchingNextPage,
   onClose,
-  onDeleteNotification,
-  // onAllMessagesRead,
 }: NotificationModalProps) => {
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
+  const { ref: infiniteScrollRef, inView } = useInView({
+    threshold: 0.1,
+  });
 
   const router = useRouter();
   const { userInfo } = useAuthStore();
@@ -92,6 +92,12 @@ const NotificationModal = ({
     () => () => {},
   );
 
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   const showErrorAlert = (errorMessage: string | null) => {
     setAlertMessage(
       errorMessage ||
@@ -101,6 +107,13 @@ const NotificationModal = ({
   };
 
   useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    console.log('NotificationModal에 전달된 notifications:', notifications);
     // 서버에서 현재 시간을 가져오는 API 호출
     const fetchServerTime = async () => {
       try {
@@ -148,11 +161,9 @@ const NotificationModal = ({
         const updatedNotifications = notifications.map(notification =>
           notification.id === updatedNotification.id
             ? { ...notification, read: true }
-            : // updatedNotification
-              notification,
+            : notification,
         );
-        onDeleteNotification(updatedNotifications);
-        setNotifications(updatedNotifications);
+        onUpdateNotifications(updatedNotifications);
       }
     }
 
@@ -202,8 +213,7 @@ const NotificationModal = ({
             ...notification,
             read: true,
           }));
-          setNotifications(updatedNotifications);
-          onDeleteNotification(updatedNotifications);
+          onUpdateNotifications(updatedNotifications);
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert);
@@ -237,8 +247,7 @@ const NotificationModal = ({
           const updatedNotifications = notifications.filter(
             notification => notification.id !== notificationId,
           );
-          onDeleteNotification(updatedNotifications);
-          setNotifications(updatedNotifications); // 알림 상태 갱신
+          onUpdateNotifications(updatedNotifications);
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert);
@@ -260,20 +269,6 @@ const NotificationModal = ({
     setConfirmMessage('모든 알림을 삭제하시겠습니까?');
     setOnConfirmCallback(() => async () => {
       try {
-        const unreadNotifications = notifications.filter(
-          notification => !notification.read,
-        );
-
-        if (unreadNotifications.length > 0) {
-          for (const notification of unreadNotifications) {
-            await markNotificationAsRead(notification.id);
-          }
-
-          // const updatedNotifications = notifications.map(notification => ({
-          //   ...notification,
-          //   read: true,
-          // }));
-        }
         const response = await axiosInstance.delete(
           `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/notification/user/${userId}`,
           {
@@ -287,8 +282,7 @@ const NotificationModal = ({
           setShowAlert(true);
 
           // 알림 삭제 후 상태 갱신
-          setNotifications([]);
-          onDeleteNotification([]);
+          onUpdateNotifications([]);
         }
       } catch (error: any) {
         handleApiError(error, showErrorAlert);
@@ -335,135 +329,147 @@ const NotificationModal = ({
           )}
 
           {notifications.length > 0 ? (
-            <ul className="space-y-2 text-md overflow-y-auto md:max-h-[600px] max-h-[350px]">
-              {notifications
-                .slice()
-                .sort(
-                  (a, b) =>
-                    new Date(b.createdAt).getTime() -
-                    new Date(a.createdAt).getTime(),
-                )
-                .map((notification, index) => {
-                  let message: ReactNode = '';
+            <div className="overflow-y-auto max-h-[60vh]">
+              <ul className="space-y-2 text-md">
+                {notifications
+                  .slice()
+                  .sort(
+                    (a, b) =>
+                      new Date(b.createdAt).getTime() -
+                      new Date(a.createdAt).getTime(),
+                  )
+                  .map((notification, index) => {
+                    let message: ReactNode = '';
 
-                  switch (notification.type) {
-                    case 'COMMENT_ADDED':
-                      message = (
-                        <>
-                          [🔔 댓글]{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.sender.nickname}
-                          </strong>
-                          님이{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.postTitle}
-                          </strong>{' '}
-                          게시글에 댓글을 남겼습니다.
-                        </>
-                      );
-                      break;
-                    case 'REPLY_ADDED':
-                      message = (
-                        <>
-                          [🔔 답글]{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.sender.nickname}
-                          </strong>
-                          님이 당신의 댓글에 답글을 남겼습니다.
-                        </>
-                      );
-                      break;
-                    case 'STUDY_SIGNUP_ADDED':
-                      message = (
-                        <>
-                          [🔥 스터디]{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.sender.nickname}
-                          </strong>
-                          님이{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.studyName}
-                          </strong>{' '}
-                          스터디 신청 요청을 보냈습니다.
-                        </>
-                      );
-                      break;
-                    case 'STUDY_SIGNUP_APPROVED':
-                      message = (
-                        <>
-                          [🔥 스터디]{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.sender.nickname}
-                          </strong>
-                          님이{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.studyName}
-                          </strong>{' '}
-                          스터디 신청을 수락했습니다.
-                        </>
-                      );
-                      break;
-                    case 'STUDY_SIGNUP_REJECTED':
-                      message = (
-                        <>
-                          [🔥 스터디]{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.sender.nickname}
-                          </strong>
-                          님이{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.studyName}
-                          </strong>{' '}
-                          스터디 신청을 거절했습니다.
-                        </>
-                      );
-                      break;
-                    case 'STUDY_CREATED':
-                      message = (
-                        <>
-                          [🔥 스터디]{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.sender.nickname}
-                          </strong>
-                          님이{' '}
-                          <strong className="text-semibold text-gray-800">
-                            {notification.studyName}
-                          </strong>{' '}
-                          스터디를 개설했습니다. 마이페이지에서 채팅 및 스터디룸
-                          이용이 가능합니다!
-                        </>
-                      );
-                      break;
-                  }
-                  return (
-                    <li
-                      key={index}
-                      onClick={() => handleNotificationClick(notification.id)}
-                      className={`p-3 border-b border-gray-200 cursor-pointer hover:bg-gray-200 ${notification.read ? 'bg-gray-100 text-gray-700 opacity-70' : 'text-gray-800'}`}
-                    >
-                      {message}
-                      <div className="flex justify-between items-center mt-2">
-                        <div className="text-gray-500 text-sm text-right">
-                          {serverTime
-                            ? calculateTimeDifference(
-                                notification.createdAt,
-                                serverTime,
-                              )
-                            : '로딩 중...'}
+                    switch (notification.type) {
+                      case 'COMMENT_ADDED':
+                        message = (
+                          <>
+                            [🔔 댓글]{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.sender.nickname}
+                            </strong>
+                            님이{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.postTitle}
+                            </strong>{' '}
+                            게시글에 댓글을 남겼습니다.
+                          </>
+                        );
+                        break;
+                      case 'REPLY_ADDED':
+                        message = (
+                          <>
+                            [🔔 답글]{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.sender.nickname}
+                            </strong>
+                            님이 당신의 댓글에 답글을 남겼습니다.
+                          </>
+                        );
+                        break;
+                      case 'STUDY_SIGNUP_ADDED':
+                        message = (
+                          <>
+                            [🔥 스터디]{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.sender.nickname}
+                            </strong>
+                            님이{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.studyName}
+                            </strong>{' '}
+                            스터디 신청 요청을 보냈습니다.
+                          </>
+                        );
+                        break;
+                      case 'STUDY_SIGNUP_APPROVED':
+                        message = (
+                          <>
+                            [🔥 스터디]{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.sender.nickname}
+                            </strong>
+                            님이{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.studyName}
+                            </strong>{' '}
+                            스터디 신청을 수락했습니다.
+                          </>
+                        );
+                        break;
+                      case 'STUDY_SIGNUP_REJECTED':
+                        message = (
+                          <>
+                            [🔥 스터디]{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.sender.nickname}
+                            </strong>
+                            님이{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.studyName}
+                            </strong>{' '}
+                            스터디 신청을 거절했습니다.
+                          </>
+                        );
+                        break;
+                      case 'STUDY_CREATED':
+                        message = (
+                          <>
+                            [🔥 스터디]{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.sender.nickname}
+                            </strong>
+                            님이{' '}
+                            <strong className="text-semibold text-gray-800">
+                              {notification.studyName}
+                            </strong>{' '}
+                            스터디를 개설했습니다. 마이페이지에서 채팅 및
+                            스터디룸 이용이 가능합니다!
+                          </>
+                        );
+                        break;
+                    }
+                    return (
+                      <li
+                        key={notification.id}
+                        onClick={() => handleNotificationClick(notification.id)}
+                        className={`p-3 border-b border-gray-200 cursor-pointer hover:bg-gray-200 ${notification.read ? 'bg-gray-100 text-gray-700 opacity-70' : 'text-gray-800'}`}
+                        ref={
+                          index === notifications.length - 1
+                            ? infiniteScrollRef
+                            : null
+                        }
+                      >
+                        {message}
+                        <div className="flex justify-between items-center mt-2">
+                          <div className="text-gray-500 text-sm text-right">
+                            {serverTime
+                              ? calculateTimeDifference(
+                                  notification.createdAt,
+                                  serverTime,
+                                )
+                              : '로딩 중...'}
+                          </div>
+                          <button
+                            onClick={e =>
+                              handleNotificationDeleteClick(notification.id, e)
+                            }
+                            className="text-sm text-red-500 hover:text-red-700"
+                          >
+                            삭제
+                          </button>
                         </div>
-                        <button
-                          onClick={e =>
-                            handleNotificationDeleteClick(notification.id, e)
-                          }
-                          className="text-sm text-red-500 hover:text-red-700"
-                        >
-                          삭제
-                        </button>
-                      </div>
-                    </li>
-                  );
-                })}
-            </ul>
+                      </li>
+                    );
+                  })}
+              </ul>
+              {isFetchingNextPage && (
+                <div className="text-center py-4 text-gray-500">
+                  알림을 불러오는 중..
+                </div>
+              )}
+            </div>
           ) : (
             <p className="text-gray-500">새로운 알림이 없습니다.</p>
           )}

--- a/src/components/layout/Header/NotificationModal.tsx
+++ b/src/components/layout/Header/NotificationModal.tsx
@@ -260,6 +260,20 @@ const NotificationModal = ({
     setConfirmMessage('모든 알림을 삭제하시겠습니까?');
     setOnConfirmCallback(() => async () => {
       try {
+        const unreadNotifications = notifications.filter(
+          notification => !notification.read,
+        );
+
+        if (unreadNotifications.length > 0) {
+          for (const notification of unreadNotifications) {
+            await markNotificationAsRead(notification.id);
+          }
+
+          // const updatedNotifications = notifications.map(notification => ({
+          //   ...notification,
+          //   read: true,
+          // }));
+        }
         const response = await axiosInstance.delete(
           `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/notification/user/${userId}`,
           {
@@ -321,7 +335,7 @@ const NotificationModal = ({
           )}
 
           {notifications.length > 0 ? (
-            <ul className="space-y-2 text-md">
+            <ul className="space-y-2 text-md overflow-y-auto md:max-h-[600px] max-h-[350px]">
               {notifications
                 .slice()
                 .sort(

--- a/src/components/layout/Header/NotificationModal.tsx
+++ b/src/components/layout/Header/NotificationModal.tsx
@@ -1,72 +1,17 @@
+'use client';
+
 import CustomAlert from '@/components/common/Alert';
 import CustomConfirm from '@/components/common/Confirm';
 import { useAuthStore } from '@/store/authStore';
-import { User } from '@/types/post';
 import axiosInstance from '@/utils/axios';
 import handleApiError from '@/utils/handleApiError';
 import axios from 'axios';
-import { ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FaCheck, FaTrashAlt } from 'react-icons/fa';
 import { useRouter } from 'next/navigation';
 import { useInView } from 'react-intersection-observer';
-
-export type Notification = {
-  id: number;
-  userId: number;
-  sender: User;
-  type: string;
-  createdAt: string;
-  postType: string;
-  postTitle: string | null;
-  postContent: string | null;
-  commentContent: string | null;
-  replyContent: string | null;
-  studyName: string | null;
-  targetId: number;
-  read: boolean;
-};
-
-type NotificationModalProps = {
-  notifications: Notification[];
-  onUpdateNotifications: (notifications: Notification[]) => void;
-  hasNextPage?: boolean;
-  fetchNextPage: () => void;
-  isFetchingNextPage?: boolean;
-  onClose: () => void;
-};
-
-// 시간 차이를 계산하는 함수
-const calculateTimeDifference = (createdAt: string, serverTime: string) => {
-  const serverDate = new Date(serverTime); // 서버 시간 UTC -> KST 변환
-  const createdDate = new Date(createdAt); // 알림 시간 (이미 KST)
-
-  const diffInSeconds = Math.floor(
-    (serverDate.getTime() - createdDate.getTime()) / 1000,
-  );
-  const diffInMinutes = Math.floor(diffInSeconds / 60);
-  const diffInHours = Math.floor(diffInMinutes / 60);
-  const diffInDays = Math.floor(diffInHours / 24);
-  const diffInMonths = Math.floor(diffInDays / 30);
-  const diffInYears = Math.floor(diffInDays / 365);
-
-  // 차이 계산 후 결과 반환
-  if (diffInYears >= 1) {
-    return `${diffInYears}년 전`;
-  }
-  if (diffInMonths >= 1) {
-    return `${diffInMonths}개월 전`;
-  }
-  if (diffInDays >= 1) {
-    return `${diffInDays}일 전`;
-  }
-  if (diffInHours >= 1) {
-    return `${diffInHours}시간 전`;
-  }
-  if (diffInMinutes >= 1) {
-    return `${diffInMinutes}분 전`;
-  }
-  return '방금 전';
-};
+import NotificationItem from './NotificationItem';
+import { NotificationModalProps } from '@/types/notification';
 
 const NotificationModal = ({
   notifications,
@@ -122,7 +67,6 @@ const NotificationModal = ({
         );
         if (response.status === 200) {
         }
-        console.log('현재 시간은', response.data.currentTime);
         setServerTime(response.data.currentTime);
       } catch (error) {
         console.error('서버 시간을 가져오는 데 실패하였습니다.', error);
@@ -338,131 +282,17 @@ const NotificationModal = ({
                       new Date(b.createdAt).getTime() -
                       new Date(a.createdAt).getTime(),
                   )
-                  .map((notification, index) => {
-                    let message: ReactNode = '';
-
-                    switch (notification.type) {
-                      case 'COMMENT_ADDED':
-                        message = (
-                          <>
-                            [🔔 댓글]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.postTitle}
-                            </strong>{' '}
-                            게시글에 댓글을 남겼습니다.
-                          </>
-                        );
-                        break;
-                      case 'REPLY_ADDED':
-                        message = (
-                          <>
-                            [🔔 답글]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이 당신의 댓글에 답글을 남겼습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_SIGNUP_ADDED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디 신청 요청을 보냈습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_SIGNUP_APPROVED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디 신청을 수락했습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_SIGNUP_REJECTED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디 신청을 거절했습니다.
-                          </>
-                        );
-                        break;
-                      case 'STUDY_CREATED':
-                        message = (
-                          <>
-                            [🔥 스터디]{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.sender.nickname}
-                            </strong>
-                            님이{' '}
-                            <strong className="text-semibold text-gray-800">
-                              {notification.studyName}
-                            </strong>{' '}
-                            스터디를 개설했습니다. 마이페이지에서 채팅 및
-                            스터디룸 이용이 가능합니다!
-                          </>
-                        );
-                        break;
-                    }
-                    return (
-                      <li
-                        key={notification.id}
-                        onClick={() => handleNotificationClick(notification.id)}
-                        className={`p-3 border-b border-gray-200 cursor-pointer hover:bg-gray-200 ${notification.read ? 'bg-gray-100 text-gray-700 opacity-70' : 'text-gray-800'}`}
-                        ref={
-                          index === notifications.length - 1
-                            ? infiniteScrollRef
-                            : null
-                        }
-                      >
-                        {message}
-                        <div className="flex justify-between items-center mt-2">
-                          <div className="text-gray-500 text-sm text-right">
-                            {serverTime
-                              ? calculateTimeDifference(
-                                  notification.createdAt,
-                                  serverTime,
-                                )
-                              : '로딩 중...'}
-                          </div>
-                          <button
-                            onClick={e =>
-                              handleNotificationDeleteClick(notification.id, e)
-                            }
-                            className="text-sm text-red-500 hover:text-red-700"
-                          >
-                            삭제
-                          </button>
-                        </div>
-                      </li>
-                    );
-                  })}
+                  .map((notification, index) => (
+                    <NotificationItem
+                      key={notification.id}
+                      notification={notification}
+                      serverTime={serverTime}
+                      onClick={handleNotificationClick}
+                      onDelete={handleNotificationDeleteClick}
+                      isLast={index === notifications.length - 1}
+                      lastItemRef={infiniteScrollRef}
+                    />
+                  ))}
               </ul>
               {isFetchingNextPage && (
                 <div className="text-center py-4 text-gray-500">

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -273,23 +273,6 @@ const Header = () => {
     fetchNotifications(); // 컴포넌트가 마운트될 때 알림 조회
   }, [isSignedIn, userInfo]);
 
-  // useEffect(() => {
-  //   if (userInfo?.id && userInfo?.id > 0) {
-  //     setUserId(userInfo.id);
-  //   } else {
-  //     setUserId(null);
-  //   }
-  // }, [userInfo]);
-
-  // useEffect(() => {
-  //   if (isSignedIn && userInfo?.id) {
-  //     connect();
-  //   } else {
-  //     setUserId(null);
-  //     disconnect();
-  //   }
-  // }, [isSignedIn, connect, disconnect]);
-
   // pathname이 변경될 때마다 현재 활성화된 메뉴 설정
   useEffect(() => {
     const handleRouteChange = () => {

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -217,14 +217,19 @@ const Header = () => {
   const [activeMenu, setActiveMenu] = useState<string>('');
 
   const [userId, setUserId] = useState<number | null>(null);
-  const { newNotifications, connect, disconnect } = useNotification(
+  const {
+    updateNotificationCache,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    connect,
+    disconnect,
+  } = useNotification(userId || 0);
+  const { notifications }: { notifications: Notification[] } = useNotification(
     userId || 0,
   );
   const [isNotificationModalOpen, setNotificationModalOpen] = useState(false);
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [notificationCount, setNotificationCount] = useState(
-    notifications.length,
-  );
+  const unreadCount = notifications.filter((n: Notification) => !n.read).length;
 
   const pathname = usePathname();
   const router = useRouter();
@@ -246,32 +251,15 @@ const Header = () => {
     if (isSignedIn && userInfo?.id && userInfo?.id > 0) {
       setUserId(userInfo.id);
       connect();
-
-      if (newNotifications.length > 0) {
-        // 중복되지 않는 알림만 추가하기
-        const uniqueNotifications = newNotifications.filter(
-          newNotification =>
-            !notifications.some(
-              existingNotification =>
-                existingNotification.id === newNotification.id,
-            ),
-        );
-
-        // 중복되지 않는 알림만 상태에 추가
-        if (uniqueNotifications.length > 0) {
-          setNotifications(prev => [...prev, ...uniqueNotifications]);
-          setNotificationCount(prev => prev + uniqueNotifications.length);
-        }
-      }
     } else {
       setUserId(null);
       disconnect();
     }
-  }, [isSignedIn, userInfo, connect, disconnect, newNotifications]);
+  }, [isSignedIn, userInfo, connect, disconnect, notifications]);
 
   useEffect(() => {
-    fetchNotifications(); // 컴포넌트가 마운트될 때 알림 조회
-  }, [isSignedIn, userInfo]);
+    console.log('Header에서 notifications 상태 변경 감지:', notifications);
+  }, [notifications]);
 
   // pathname이 변경될 때마다 현재 활성화된 메뉴 설정
   useEffect(() => {
@@ -327,41 +315,8 @@ const Header = () => {
     setShowAlert(true);
   };
 
-  const fetchNotifications = async () => {
-    try {
-      if (isSignedIn && userInfo?.id) {
-        const response = await axiosInstance.get(
-          `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/notification/?page=0`,
-          {
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
-        if (response.status === 200 && response.data) {
-          const fetchedNotifications = response.data.content || [];
-          console.log('알림 조회 데이터:', response.data.content);
-          setNotifications(fetchedNotifications);
-          setNotificationCount(
-            fetchedNotifications.filter(
-              (notification: any) => !notification.read,
-            ).length,
-          ); // 읽지 않은 알림 카운트
-        }
-      }
-    } catch (error: any) {
-      console.error('알림 조회 실패:', error);
-      handleApiError(error, showErrorAlert);
-    } finally {
-      setShowConfirm(false);
-    }
-  };
-
-  // 알림 삭제 후 상태 갱신 함수
-  const updateNotificationCount = (updatedNotifications: Notification[]) => {
-    setNotifications(updatedNotifications);
-    setNotificationCount(
-      updatedNotifications.filter((notification: any) => !notification.read)
-        .length,
-    );
+  const handleNotificationUpdate = (updatedNotifications: Notification[]) => {
+    updateNotificationCache(() => updatedNotifications);
   };
 
   const handleSignOutClick = async () => {
@@ -410,7 +365,7 @@ const Header = () => {
       <div className="navbar-end hidden lg:flex space-x-2">
         {isSignedIn && (
           <NotificationButton
-            count={notificationCount}
+            count={unreadCount}
             onClick={toggleNotificationModal}
             isActive={isNotificationModalOpen}
           />
@@ -430,7 +385,7 @@ const Header = () => {
       <div className="navbar-end lg:hidden">
         {isSignedIn && (
           <NotificationButton
-            count={notificationCount}
+            count={unreadCount}
             onClick={toggleNotificationModal}
             isActive={isNotificationModalOpen}
           />
@@ -480,9 +435,10 @@ const Header = () => {
       {isNotificationModalOpen && (
         <NotificationModal
           notifications={notifications}
-          setNotifications={setNotifications}
-          setNotificationCount={setNotificationCount}
-          onDeleteNotification={updateNotificationCount}
+          onUpdateNotifications={handleNotificationUpdate}
+          hasNextPage={hasNextPage}
+          fetchNextPage={fetchNextPage}
+          isFetchingNextPage={isFetchingNextPage}
           onClose={toggleNotificationModal}
         />
       )}

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -11,8 +11,10 @@ import CustomAlert from '@/components/common/Alert';
 import { FiBell } from 'react-icons/fi';
 import axiosInstance from '@/utils/axios';
 import handleApiError from '@/utils/handleApiError';
-import NotificationModal, { Notification } from './NotificationModal';
+import NotificationModal from './NotificationModal';
 import useNotification from '@/hooks/useNotification';
+import useWebSocket from '@/hooks/useWebSocket';
+import { Notification } from '@/types/notification';
 
 type NavigationItem = {
   path: string;
@@ -222,9 +224,8 @@ const Header = () => {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    connect,
-    disconnect,
   } = useNotification(userId || 0);
+  const { connect, disconnect } = useWebSocket(userId || 0);
   const { notifications }: { notifications: Notification[] } = useNotification(
     userId || 0,
   );

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -2,11 +2,101 @@ import { Client } from '@stomp/stompjs';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import SockJS from 'sockjs-client';
 import { Notification } from '@/components/layout/Header/NotificationModal';
-const useNotification = (userId: number) => {
-  const stompClient = useRef<Client | null>(null);
-  const [newNotifications, setNewNotifications] = useState<Notification[]>([]);
-  const [isConnected, setIsConnected] = useState(false);
+import { useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
+import axiosInstance from '@/utils/axios';
 
+const NOTIFICATION_QUERY_KEY = 'notifications';
+
+// 알림 데이터 타입 정의
+// interface NotificationResponse {
+//   content: Notification[];
+//   last: boolean;
+//   totalElements: number;
+//   totalPages: number;
+// }
+
+const useNotification = (userId: number) => {
+  const queryClient = useQueryClient();
+  const stompClient = useRef<Client | null>(null);
+  const [, setIsConnected] = useState(false);
+
+  // 알림 쿼리 키 생성 함수
+  const getNotificationsQueryKey = useCallback(
+    () => [NOTIFICATION_QUERY_KEY, userId],
+    [userId],
+  );
+
+  // 알림 데이터 조회 함수
+  const fetchNotificationPage = async ({ pageParam = 0 }) => {
+    if (!userId)
+      return { content: [], last: true, totalElements: 0, totalPages: 0 };
+    const response = await axiosInstance.get(
+      `${process.env.NEXT_PUBLIC_API_ROUTE_URL}/notification/?page=${pageParam}`,
+    );
+    return response.data;
+  };
+
+  // React Query의 Infinite Query를 사용한 알림 데이터 관리
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
+    useInfiniteQuery({
+      queryKey: getNotificationsQueryKey(),
+      queryFn: fetchNotificationPage,
+      initialPageParam: 0,
+      getNextPageParam: lastPage => {
+        return lastPage.last ? undefined : lastPage.pageable.pageNumber + 1;
+      },
+      enabled: !!userId,
+      staleTime: 1000 * 60,
+    });
+
+  //  중복 제거 헬퍼 함수
+  const removeDuplicates = (notifications: Notification[]) => {
+    const uniqueNotifications = new Map();
+    for (const notification of notifications) {
+      uniqueNotifications.set(notification.id, notification);
+    }
+
+    return Array.from(uniqueNotifications.values());
+  };
+
+  // 모든 알림을 플랫하게 만들어주는 헬퍼 함수
+  const notifications = removeDuplicates(
+    data?.pages.flatMap(page => page.content) ?? [],
+  );
+
+  // 알림 캐시 업데이트 함수
+  const updateNotificationCache = useCallback(
+    (updater: (prev: Notification[]) => Notification[]) => {
+      queryClient.setQueryData(getNotificationsQueryKey(), (old: any) => {
+        if (!old?.pages) return old;
+
+        // 첫 페이지의 데이터만 업데이트
+        const updatedFirstPage = {
+          ...old.pages[0],
+          content: updater(old.pages[0].content),
+        };
+
+        return {
+          ...old,
+          pages: [updatedFirstPage, ...old.pages.slice(1)],
+        };
+      });
+    },
+    [queryClient, getNotificationsQueryKey],
+  );
+
+  // 새 알림 추가 함수
+  const addNewNotification = useCallback(
+    (newNotification: Notification) => {
+      updateNotificationCache(prev => {
+        const isDuplicate = prev.some(n => n.id === newNotification.id);
+        return isDuplicate ? prev : [newNotification, ...prev];
+      });
+    },
+    [updateNotificationCache],
+  );
+
+  // WebSocket 연결 함수
   const connect = useCallback(() => {
     if (!userId || stompClient.current?.connected) return;
 
@@ -19,24 +109,13 @@ const useNotification = (userId: number) => {
       onConnect: () => {
         setIsConnected(true);
         console.log('알림 WebSocket 연결 성공');
-        console.log('userId: ' + userId);
         client.subscribe(`/topic/notifications/${userId}`, message => {
-          console.log('새 알림 메시지 수신:', message.body);
-          const notification = JSON.parse(message.body);
-          // 중복 체크: 동일한 알림 ID가 이미 존재하는지 확인
-          setNewNotifications(prev => {
-            const isDuplicate = prev.some(
-              existingNotification =>
-                existingNotification.id === notification.id,
-            );
-
-            // 중복되지 않으면 알림 추가
-            if (isDuplicate) {
-              return prev;
-            } else {
-              return [...prev, notification];
-            }
-          });
+          try {
+            const notification = JSON.parse(message.body);
+            addNewNotification(notification);
+          } catch (error) {
+            console.error('알림 메시지 파싱 오류:', error);
+          }
         });
       },
       onDisconnect: () => {
@@ -49,26 +128,34 @@ const useNotification = (userId: number) => {
     });
 
     stompClient.current = client;
-    console.log('WebSocket 클라이언트 활성화 시작');
     client.activate();
-  }, [userId]);
+  }, [userId, addNewNotification]);
 
+  // WebSocket 연결 해제 함수
   const disconnect = useCallback(() => {
     if (stompClient.current?.connected) {
       stompClient.current.deactivate();
       stompClient.current = null;
       setIsConnected(false);
     }
-  }, [userId]);
+  }, []);
 
+  // WebSocket 연결 관리
   useEffect(() => {
-    console.log('현재 userId:', userId);
     if (userId) connect();
-    // connect();
     return () => disconnect();
   }, [userId, connect, disconnect]);
 
-  return { newNotifications, isConnected, connect, disconnect };
+  return {
+    notifications,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    status,
+    connect,
+    disconnect,
+    updateNotificationCache,
+  };
 };
 
 export default useNotification;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Client, StompSubscription } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+interface WebSocketState {
+  isConnected: boolean;
+  error: string | null;
+}
+
+const useWebSocket = (
+  userId: number,
+  // onMessageReceived: (message: any) => void,
+) => {
+  const stompClient = useRef<Client | null>(null);
+  const subscriptions = useRef<Map<string, StompSubscription>>(new Map());
+  const isConnecting = useRef<boolean>(false);
+  const [webSocketState, setWebSocketState] = useState<WebSocketState>({
+    isConnected: false,
+    error: null,
+  });
+  // const [, setIsConnected] = useState(false);
+
+  // WebSocket 연결 함수
+  const connect = useCallback(() => {
+    if (!userId || isConnecting.current || stompClient.current?.connected)
+      return;
+
+    isConnecting.current = true;
+
+    const socket = new SockJS(
+      `${process.env.NEXT_PUBLIC_CHAT_SOCKET_URL}/ws` as string,
+    );
+
+    if (stompClient.current) {
+      stompClient.current.deactivate();
+      stompClient.current = null;
+    }
+
+    const client = new Client({
+      webSocketFactory: () => socket,
+      reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000,
+      onConnect: () => {
+        isConnecting.current = false;
+        setWebSocketState({ isConnected: true, error: null });
+        console.log('알림 WebSocket 연결 성공');
+        // client.subscribe(`/topic/notifications/${userId}`, message => {
+        //   try {
+        //     const parsedMessage = JSON.parse(message.body);
+        //     onMessageReceived(parsedMessage);
+        //   } catch (error) {
+        //     console.error('알림 메시지 파싱 오류:', error);
+        //   }
+        // });
+      },
+      onDisconnect: () => {
+        isConnecting.current = false;
+        setWebSocketState(prev => ({ ...prev, isConnected: false }));
+        console.log('알림 WebSocket 연결 해제됨');
+      },
+      onStompError: error => {
+        isConnecting.current = false;
+        setWebSocketState(prev => ({
+          ...prev,
+          error: error.headers?.message || '연결 오류가 발생했습니다.',
+        }));
+        console.error('WebSocket 오류:', error);
+      },
+    });
+
+    stompClient.current = client;
+    client.activate();
+  }, [userId]);
+
+  // 토픽 구독 함수
+  const subscribe = useCallback(
+    (topic: string, callback: (message: any) => void) => {
+      if (!stompClient.current?.connected) {
+        throw new Error('WebSocket이 연결되어 있지 않습니다.');
+      }
+
+      if (!subscriptions.current.has(topic)) {
+        const subscription = stompClient.current.subscribe(topic, message => {
+          try {
+            const parsedMessage = JSON.parse(message.body);
+            callback(parsedMessage);
+          } catch (error) {
+            console.error('메시지 파싱 오류:', error);
+          }
+        });
+        subscriptions.current.set(topic, subscription);
+        console.log(`${topic} 구독 성공`);
+      }
+    },
+    [],
+  );
+
+  // 토픽 구독 해제 함수
+  const unsubscribe = useCallback((topic: string) => {
+    const subscription = subscriptions.current.get(topic);
+    if (subscription) {
+      subscription.unsubscribe();
+      subscriptions.current.delete(topic);
+      console.log(`${topic} 구독 취소`);
+    }
+  }, []);
+
+  // WebSocket 연결 해제 함수
+  const disconnect = useCallback(() => {
+    // 모든 구독 취소
+    subscriptions.current.forEach(subscription => {
+      subscription.unsubscribe();
+    });
+    subscriptions.current.clear();
+
+    if (stompClient.current?.connected) {
+      stompClient.current.deactivate();
+      stompClient.current = null;
+      setWebSocketState({ isConnected: false, error: null });
+    }
+  }, []);
+
+  // 웹소켓 publish 함수(채팅)
+  const publish = useCallback((destination: string, body: string) => {
+    if (!stompClient.current?.connected) {
+      throw new Error('WebSocket이 연결되어 있지 않습니다.');
+    }
+
+    stompClient.current.publish({
+      destination,
+      body,
+    });
+  }, []);
+
+  // WebSocket 연결 관리
+  useEffect(() => {
+    if (userId) connect();
+    return () => disconnect();
+  }, [userId, connect, disconnect]);
+
+  return {
+    webSocketState,
+    subscribe,
+    unsubscribe,
+    publish,
+    connect,
+    disconnect,
+  };
+};
+
+export default useWebSocket;

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,99 @@
+import { User } from './post';
+
+export type Notification = {
+  id: number;
+  userId: number;
+  sender: User;
+  type: NotificationType;
+  createdAt: string;
+  postType: string;
+  postTitle: string | null;
+  postContent: string | null;
+  commentContent: string | null;
+  replyContent: string | null;
+  studyName: string | null;
+  targetId: number;
+  read: boolean;
+};
+
+export enum PostType {
+  STUDY = 'STUDY',
+  INFO = 'INFO',
+  QNA = 'QNA',
+}
+
+export type NotificationModalProps = {
+  notifications: Notification[];
+  onUpdateNotifications: (notifications: Notification[]) => void;
+  hasNextPage?: boolean;
+  fetchNextPage: () => void;
+  isFetchingNextPage?: boolean;
+  onClose: () => void;
+};
+
+export interface NotificationContent {
+  postTitle?: string | null;
+  postContent?: string | null;
+  commentContent?: string | null;
+  replyContent?: string | null;
+  studyName?: string | null;
+}
+
+export const NotificationType = {
+  COMMENT_ADDED: 'COMMENT_ADDED',
+  REPLY_ADDED: 'REPLY_ADDED',
+  STUDY_SIGNUP_ADDED: 'STUDY_SIGNUP_ADDED',
+  STUDY_SIGNUP_APPROVED: 'STUDY_SIGNUP_APPROVED',
+  STUDY_SIGNUP_REJECTED: 'STUDY_SIGNUP_REJECTED',
+  STUDY_CREATED: 'STUDY_CREATED',
+} as const;
+
+type NotificationType =
+  (typeof NotificationType)[keyof typeof NotificationType];
+
+export interface NotificationMessage {
+  icon: string;
+  prefix: string;
+  getMessage: (notification: Notification) => string;
+}
+
+export const NOTIFICATION_MESSAGES: Record<
+  NotificationType,
+  NotificationMessage
+> = {
+  [NotificationType.COMMENT_ADDED]: {
+    icon: '🔔',
+    prefix: '댓글',
+    getMessage: notification =>
+      `님이 <strong>${notification.postTitle}</strong> 게시글에 댓글을 남겼습니다.`,
+  },
+  [NotificationType.REPLY_ADDED]: {
+    icon: '🔔',
+    prefix: '답글',
+    getMessage: () => '님이 당신의 댓글에 답글을 남겼습니다.',
+  },
+  [NotificationType.STUDY_SIGNUP_ADDED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디 신청 요청을 보냈습니다.`,
+  },
+  [NotificationType.STUDY_SIGNUP_APPROVED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디 신청을 수락했습니다.`,
+  },
+  [NotificationType.STUDY_SIGNUP_REJECTED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디 신청을 거절했습니다.`,
+  },
+  [NotificationType.STUDY_CREATED]: {
+    icon: '🔥',
+    prefix: '스터디',
+    getMessage: notification =>
+      `님이 <strong>${notification.studyName}</strong> 스터디를 개설했습니다. 마이페이지에서 채팅 및 스터디룸 이용이 가능합니다!`,
+  },
+};


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 웹소켓 연결
    - 알림 기능과 채팅 기능에서 각각 웹소켓 연결 구현
- 알림
    - 로컬 상태(useState)로 알림 데이터 관리하여 비효율적
    - 여러 곳에서 알림 상태를 관리하고 있어 동기화 문제 발생 가능성 높음
 - 채팅
    - 채팅방 입장 시 웹소켓 연결 후 채팅 토픽 구독, 채팅방 퇴장 시 웹소켓 연결 끊김

**TO-BE**
- 웹소켓 연결
    - useWebSocket.ts 훅 함수파일을 만들어 로그인 시에 웹소켓 연결하여 단일 웹소켓 연결 유지
- 알림
    - useNotification 훅 함수 내에서 데이터 fetching, 캐싱, 실시간 알림 수신 및 무한스크롤을 구현하도록 수정
    - useInfiniteQuery를 활용하여 데이터 fetching 및 캐시 저장
    - useQueryClient를 활용하여 캐시 데이터 확인 및 업데이트를 하도록 수정
    - useInview 활용하여 무한스크롤 구현
    - 로그인 상태일때는 항상 알림 토픽 구독 상태
    - NotificationMessage, NotificationItem, NotificationModal 컴포넌트 분리
    - Notification.ts 파일에서 notification 관련 타입 관리
- 채팅
    - 채팅방 입장 시 채팅 토픽 구독, 퇴장 시 채팅 토픽 구독 해제
    - 채팅 메시지 전송 시 useWebSocket.ts 파일의 publish 함수 이용하여 메시지 발행