### PR TITLE
fix: 알림 개수 불러오는 로직 수정, 알림 캐시 업데이트 시 첫 페이지 제외한 알림 업데이트 에러 해결 / refactor: 헤더 컴포넌트 내에 있는 컴포넌트 각각의 파일로 분리

### DIFF
--- a/src/components/layout/Header/Logo.tsx
+++ b/src/components/layout/Header/Logo.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+
+const Logo = () => (
+  <Link
+    href="/"
+    className="btn btn-ghost text-base-content text-center overflow-hidden"
+  >
+    <div className="flex flex-col items-center">
+      <span className="block text-xs text-black">
+        스마트한 개발 스터디 플랫폼
+      </span>
+      <span className="block text-xl font-bold text-teal-500">
+        <Image
+          src={'/devonoff-logo.png'}
+          alt={'DevOnOff 로고'}
+          width={185}
+          height={185}
+          className="object-contain -mt-20"
+          priority
+        />
+      </span>
+    </div>
+  </Link>
+);
+
+export default Logo;

--- a/src/components/layout/Header/Navigation.tsx
+++ b/src/components/layout/Header/Navigation.tsx
@@ -1,0 +1,34 @@
+'use client';
+import Link from 'next/link';
+import { NavigationItem } from '@/types/navigation';
+
+type NavigationProps = {
+  items: NavigationItem[];
+  activeMenu: string;
+  onMenuClick: (menu: string) => void;
+  className?: string;
+  itemClassName?: string;
+};
+
+const Navigation = ({
+  items,
+  activeMenu,
+  onMenuClick,
+  className = '',
+  itemClassName = '',
+}: NavigationProps) => (
+  <nav className={className}>
+    {items.map(item => (
+      <Link
+        key={item.id}
+        href={item.path}
+        className={`btn ${itemClassName} ${activeMenu === item.id ? 'btn-active' : ''}`}
+        onClick={() => onMenuClick(item.id)}
+      >
+        {item.label}
+      </Link>
+    ))}
+  </nav>
+);
+
+export default Navigation;

--- a/src/components/layout/Header/NotificationButton.tsx
+++ b/src/components/layout/Header/NotificationButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { FiBell } from 'react-icons/fi';
+
+const NotificationButton = ({
+  count,
+  onClick,
+  isActive,
+}: {
+  count: number;
+  onClick: () => void;
+  isActive: boolean;
+}) => (
+  <button
+    className={`btn btn-ghost relative ${isActive ? 'btn-active' : ''}`}
+    onClick={onClick}
+  >
+    <FiBell size={24} />
+    {count > 0 && (
+      <div className="absolute -top-1 -right-0.5 bg-customRed text-white rounded-full min-w-5 h-5 px-1 flex items-center justify-center text-xs">
+        {count > 99 ? '99+' : count}
+      </div>
+    )}
+  </button>
+);
+
+export default NotificationButton;

--- a/src/components/layout/Header/NotificationModal.tsx
+++ b/src/components/layout/Header/NotificationModal.tsx
@@ -37,20 +37,6 @@ const NotificationModal = ({
     () => () => {},
   );
 
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
-  const showErrorAlert = (errorMessage: string | null) => {
-    setAlertMessage(
-      errorMessage ||
-        '알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
-    );
-    setShowAlert(true);
-  };
-
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
@@ -75,6 +61,20 @@ const NotificationModal = ({
 
     fetchServerTime();
   }, []);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const showErrorAlert = (errorMessage: string | null) => {
+    setAlertMessage(
+      errorMessage ||
+        '알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+    );
+    setShowAlert(true);
+  };
 
   const markNotificationAsRead = async (notificationId: number) => {
     try {

--- a/src/components/layout/Header/constants.ts
+++ b/src/components/layout/Header/constants.ts
@@ -1,0 +1,8 @@
+import { NavigationItem } from '@/types/navigation';
+
+export const NAVIGATION_ITEMS: NavigationItem[] = [
+  { path: '/community/study', label: '스터디', id: 'study' },
+  { path: '/community/info', label: '정보 공유', id: 'info' },
+  { path: '/community/qna', label: 'Q&A', id: 'qna' },
+  { path: '/community/ranking', label: '랭킹', id: 'ranking' },
+];

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -1,105 +1,38 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { useAuthStore } from '@/store/authStore';
 import { usePathname } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import CustomConfirm from '@/components/common/Confirm';
 import CustomAlert from '@/components/common/Alert';
-import { FiBell } from 'react-icons/fi';
 import axiosInstance from '@/utils/axios';
 import handleApiError from '@/utils/handleApiError';
-import NotificationModal from './NotificationModal';
-import useNotification from '@/hooks/useNotification';
 import useWebSocket from '@/hooks/useWebSocket';
+import useNotification from '@/hooks/useNotification';
+import Logo from './Logo';
+import Navigation from './Navigation';
+import { NAVIGATION_ITEMS } from './constants';
 import { Notification } from '@/types/notification';
+import NotificationModal from './NotificationModal';
+import NotificationButton from './NotificationButton';
 
-type NavigationItem = {
-  path: string;
-  label: string;
-  id: string;
-};
-
-const NAVIGATION_ITEMS: NavigationItem[] = [
-  { path: '/community/study', label: '스터디', id: 'study' },
-  { path: '/community/info', label: '정보 공유', id: 'info' },
-  { path: '/community/qna', label: 'Q&A', id: 'qna' },
-  { path: '/community/ranking', label: '랭킹', id: 'ranking' },
-];
-
-const Logo = () => (
-  <Link
-    href="/"
-    className="btn btn-ghost text-base-content text-center overflow-hidden"
-  >
-    <div className="flex flex-col items-center">
-      <span className="block text-xs text-black">
-        스마트한 개발 스터디 플랫폼
-      </span>
-      <span className="block text-xl font-bold text-teal-500">
-        <Image
-          src={'/devonoff-logo.png'}
-          alt={'DevOnOff 로고'}
-          width={185}
-          height={185}
-          className="object-contain -mt-20"
-          priority
-        />
-      </span>
-    </div>
-  </Link>
-);
-
-const NotificationButton = ({
-  count,
-  onClick,
-  isActive,
-}: {
-  count: number;
-  onClick: () => void;
-  isActive: boolean;
-}) => (
-  <button
-    className={`btn btn-ghost relative ${isActive ? 'btn-active' : ''}`}
-    onClick={onClick}
-  >
-    <FiBell size={24} />
-    {count > 0 && (
-      <div className="absolute -top-1 -right-0.5 bg-customRed text-white rounded-full min-w-5 h-5 px-1 flex items-center justify-center text-xs">
-        {count > 99 ? '99+' : count}
-      </div>
-    )}
-  </button>
-);
-
-const Navigation = ({
-  items,
-  activeMenu,
-  onMenuClick,
-  className = '',
-  itemClassName = '',
-}: {
-  items: NavigationItem[];
+type AuthLinksProps = {
+  isSignedIn: boolean;
+  userInfo: any;
+  onSignOut: () => void;
   activeMenu: string;
   onMenuClick: (menu: string) => void;
   className?: string;
-  itemClassName?: string;
-}) => (
-  <nav className={className}>
-    {items.map(item => (
-      <Link
-        key={item.id}
-        href={item.path}
-        className={`btn ${itemClassName} ${activeMenu === item.id ? 'btn-active' : ''}`}
-        onClick={() => onMenuClick(item.id)}
-      >
-        {item.label}
-      </Link>
-    ))}
-  </nav>
-);
+  linkClassName?: string;
+};
+
+type MobileMenuProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
 
 const AuthLinks = ({
   isSignedIn,
@@ -109,15 +42,7 @@ const AuthLinks = ({
   onMenuClick,
   className = '',
   linkClassName = '',
-}: {
-  isSignedIn: boolean;
-  userInfo: any;
-  onSignOut: () => void;
-  activeMenu: string;
-  onMenuClick: (menu: string) => void;
-  className?: string;
-  linkClassName?: string;
-}) => (
+}: AuthLinksProps) => (
   <div className={className}>
     {isSignedIn ? (
       <>
@@ -145,15 +70,7 @@ const AuthLinks = ({
   </div>
 );
 
-const MobileMenu = ({
-  isOpen,
-  onClose,
-  children,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  children: React.ReactNode;
-}) => {
+const MobileMenu = ({ isOpen, onClose, children }: MobileMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -224,13 +141,13 @@ const Header = () => {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
+    unreadCount,
   } = useNotification(userId || 0);
   const { connect, disconnect } = useWebSocket(userId || 0);
   const { notifications }: { notifications: Notification[] } = useNotification(
     userId || 0,
   );
   const [isNotificationModalOpen, setNotificationModalOpen] = useState(false);
-  const unreadCount = notifications.filter((n: Notification) => !n.read).length;
 
   const pathname = usePathname();
   const router = useRouter();

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,5 @@
+export type NavigationItem = {
+  path: string;
+  label: string;
+  id: string;
+};


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 알림
  - 클라이언트 측에서 알림 개수 직접 계산 ➡️ page=0일 때의 알림 개수만 계산되고, 스크롤을 내려 다음 페이지 알림 api 요청을 해야 알림 개수가 정확히 계산되는 문제 발생
  - page=0에 해당하는 알림 데이터만 읽음/삭제 시 알림 내역 화면에서 회색처리/사라짐 처리가 적용되는 문제 발생
- 헤더 컴포넌트
  - 컴포넌트들을 헤더 컴포넌트 내에서 분리

**TO-BE**
- 알림
  - 알림 조회 시 알림 개수 api 요청도 함께 진행
  - 알림 캐시 업데이트 시 알림 개수 api 요청을 다시 진행하여 화면에 출력되는 개수 업데이트
- 헤더 컴포넌트
  - 컴포넌트들을 각각의 파일로 분리
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
- [X] 알림 개수 화면 출력 테스트
- [X] 알림 캐시 업데이트 테스트