### PR TITLE
fix: 알림 개수 useQuery, invalidateQuries 사용하여 관리, 회원가입 성공 알림창 제대로 뜨도록 수정, 모바일 네비게이션바 자동 닫힘 수정

### DIFF
--- a/src/app/api/notification/unread/route.ts
+++ b/src/app/api/notification/unread/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import axios from 'axios';
+
+export const GET = async () => {
+  try {
+    const response = await axios.get(
+      `${process.env.API_URL}/notification/unread`, // 백엔드 서버 URL
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (response.status === 200) {
+      return NextResponse.json(response.data, { status: response.status });
+    }
+  } catch (error: any) {
+    if (error.response) {
+      const { status, data } = error.response;
+      return NextResponse.json(data, { status });
+    }
+
+    // 네트워크 오류 처리
+    return NextResponse.json(
+      { message: '네트워크 오류가 발생했습니다.' },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/signup/components/SignUpForm.tsx
+++ b/src/app/signup/components/SignUpForm.tsx
@@ -45,6 +45,9 @@ const SignUpForm = () => {
 
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
+  const [alertCallback, setAlertCallback] = useState<() => void>(
+    () => () => {},
+  );
 
   const [isTimerActive, setIsTimerActive] = useState(false);
 
@@ -308,8 +311,8 @@ const SignUpForm = () => {
       );
       if (response.status === 200) {
         setAlertMessage('회원가입이 성공적으로 완료되었습니다!');
+        setAlertCallback(() => () => router.push('/signin'));
         setShowAlert(true);
-        router.push('/signin');
       } else {
         setAlertMessage('회원가입 중 문제가 발생했습니다. 다시 시도해 주세요.');
         setShowAlert(true);
@@ -565,7 +568,10 @@ const SignUpForm = () => {
       {showAlert && (
         <CustomAlert
           message={alertMessage}
-          onClose={() => setShowAlert(false)}
+          onClose={() => {
+            setShowAlert(false);
+            alertCallback();
+          }}
         />
       )}
     </div>

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -24,6 +24,7 @@ type AuthLinksProps = {
   onSignOut: () => void;
   activeMenu: string;
   onMenuClick: (menu: string) => void;
+  onClose?: () => void;
   className?: string;
   linkClassName?: string;
 };
@@ -40,6 +41,7 @@ const AuthLinks = ({
   onSignOut,
   activeMenu,
   onMenuClick,
+  onClose,
   className = '',
   linkClassName = '',
 }: AuthLinksProps) => (
@@ -59,10 +61,24 @@ const AuthLinks = ({
       </>
     ) : (
       <>
-        <Link href="/signin" className={`btn ${linkClassName}`}>
+        <Link
+          href="/signin"
+          className={`btn ${linkClassName}`}
+          onClick={() => {
+            onMenuClick('');
+            onClose?.();
+          }}
+        >
           로그인
         </Link>
-        <Link href="/signup" className={`btn ${linkClassName}`}>
+        <Link
+          href="/signup"
+          className={`btn ${linkClassName}`}
+          onClick={() => {
+            onMenuClick('');
+            onClose?.();
+          }}
+        >
           회원가입
         </Link>
       </>


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. -->
**AS-IS**
- 알림 개수
  - useState로 알림 개수 관리
- 회원가입
  - 회원가입 성공 시 알림창이 너무 빨리 사라져서 사용자가 회원가입을 성공했는지 확인하기 어려움
- 모바일 네비게이션바
  - 로그인, 회원가입 클릭 시 페이지 이동 후 네비게이션바가 닫히지 않음
 
**TO-BE**
- 알림 개수
  - useQuery로 알림 개수 관리하도록 수정
  - 알림 상태가 변경될 때 invalidateQueries를 사용하여 읽지 않은 알림 개수 관련 쿼리를 무효화하고 최신 데이터를 다시 가져오도록 수정
- 회원가입
  - 회원가입 성공 시 알림창이 뜨고, 확인 버튼 클릭 시 사라지도록 수정
- 모바일 네비게이션바
  - 로그인, 회원가입 클릭 시 페이지 이동 후 네비게이션바 자동으로 닫히도록 수정