### PR TITLE
merge: 알림 개수 불러오는 로직 수정, 알림 캐시 업데이트 시 첫 페이지 제외한 알림 업데이트 에러 해결, 회원가입 및 모바일네비게이션바 관련 에러 해결 후 main 브랜치로 통합

### DIFF
--- a/src/app/api/notification/unread/route.ts
+++ b/src/app/api/notification/unread/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import axios from 'axios';
+
+export const GET = async () => {
+  try {
+    const response = await axios.get(
+      `${process.env.API_URL}/notification/unread`, // 백엔드 서버 URL
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (response.status === 200) {
+      return NextResponse.json(response.data, { status: response.status });
+    }
+  } catch (error: any) {
+    if (error.response) {
+      const { status, data } = error.response;
+      return NextResponse.json(data, { status });
+    }
+
+    // 네트워크 오류 처리
+    return NextResponse.json(
+      { message: '네트워크 오류가 발생했습니다.' },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/signup/components/SignUpForm.tsx
+++ b/src/app/signup/components/SignUpForm.tsx
@@ -45,6 +45,9 @@ const SignUpForm = () => {
 
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
+  const [alertCallback, setAlertCallback] = useState<() => void>(
+    () => () => {},
+  );
 
   const [isTimerActive, setIsTimerActive] = useState(false);
 
@@ -308,8 +311,8 @@ const SignUpForm = () => {
       );
       if (response.status === 200) {
         setAlertMessage('회원가입이 성공적으로 완료되었습니다!');
+        setAlertCallback(() => () => router.push('/signin'));
         setShowAlert(true);
-        router.push('/signin');
       } else {
         setAlertMessage('회원가입 중 문제가 발생했습니다. 다시 시도해 주세요.');
         setShowAlert(true);
@@ -565,7 +568,10 @@ const SignUpForm = () => {
       {showAlert && (
         <CustomAlert
           message={alertMessage}
-          onClose={() => setShowAlert(false)}
+          onClose={() => {
+            setShowAlert(false);
+            alertCallback();
+          }}
         />
       )}
     </div>

--- a/src/components/layout/Header/Logo.tsx
+++ b/src/components/layout/Header/Logo.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+
+const Logo = () => (
+  <Link
+    href="/"
+    className="btn btn-ghost text-base-content text-center overflow-hidden"
+  >
+    <div className="flex flex-col items-center">
+      <span className="block text-xs text-black">
+        스마트한 개발 스터디 플랫폼
+      </span>
+      <span className="block text-xl font-bold text-teal-500">
+        <Image
+          src={'/devonoff-logo.png'}
+          alt={'DevOnOff 로고'}
+          width={185}
+          height={185}
+          className="object-contain -mt-20"
+          priority
+        />
+      </span>
+    </div>
+  </Link>
+);
+
+export default Logo;

--- a/src/components/layout/Header/Navigation.tsx
+++ b/src/components/layout/Header/Navigation.tsx
@@ -1,0 +1,34 @@
+'use client';
+import Link from 'next/link';
+import { NavigationItem } from '@/types/navigation';
+
+type NavigationProps = {
+  items: NavigationItem[];
+  activeMenu: string;
+  onMenuClick: (menu: string) => void;
+  className?: string;
+  itemClassName?: string;
+};
+
+const Navigation = ({
+  items,
+  activeMenu,
+  onMenuClick,
+  className = '',
+  itemClassName = '',
+}: NavigationProps) => (
+  <nav className={className}>
+    {items.map(item => (
+      <Link
+        key={item.id}
+        href={item.path}
+        className={`btn ${itemClassName} ${activeMenu === item.id ? 'btn-active' : ''}`}
+        onClick={() => onMenuClick(item.id)}
+      >
+        {item.label}
+      </Link>
+    ))}
+  </nav>
+);
+
+export default Navigation;

--- a/src/components/layout/Header/NotificationButton.tsx
+++ b/src/components/layout/Header/NotificationButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { FiBell } from 'react-icons/fi';
+
+const NotificationButton = ({
+  count,
+  onClick,
+  isActive,
+}: {
+  count: number;
+  onClick: () => void;
+  isActive: boolean;
+}) => (
+  <button
+    className={`btn btn-ghost relative ${isActive ? 'btn-active' : ''}`}
+    onClick={onClick}
+  >
+    <FiBell size={24} />
+    {count > 0 && (
+      <div className="absolute -top-1 -right-0.5 bg-customRed text-white rounded-full min-w-5 h-5 px-1 flex items-center justify-center text-xs">
+        {count > 99 ? '99+' : count}
+      </div>
+    )}
+  </button>
+);
+
+export default NotificationButton;

--- a/src/components/layout/Header/NotificationModal.tsx
+++ b/src/components/layout/Header/NotificationModal.tsx
@@ -37,20 +37,6 @@ const NotificationModal = ({
     () => () => {},
   );
 
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
-  const showErrorAlert = (errorMessage: string | null) => {
-    setAlertMessage(
-      errorMessage ||
-        '알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
-    );
-    setShowAlert(true);
-  };
-
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
@@ -75,6 +61,20 @@ const NotificationModal = ({
 
     fetchServerTime();
   }, []);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const showErrorAlert = (errorMessage: string | null) => {
+    setAlertMessage(
+      errorMessage ||
+        '알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+    );
+    setShowAlert(true);
+  };
 
   const markNotificationAsRead = async (notificationId: number) => {
     try {

--- a/src/components/layout/Header/constants.ts
+++ b/src/components/layout/Header/constants.ts
@@ -1,0 +1,8 @@
+import { NavigationItem } from '@/types/navigation';
+
+export const NAVIGATION_ITEMS: NavigationItem[] = [
+  { path: '/community/study', label: '스터디', id: 'study' },
+  { path: '/community/info', label: '정보 공유', id: 'info' },
+  { path: '/community/qna', label: 'Q&A', id: 'qna' },
+  { path: '/community/ranking', label: '랭킹', id: 'ranking' },
+];

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -1,105 +1,38 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { useAuthStore } from '@/store/authStore';
 import { usePathname } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import CustomConfirm from '@/components/common/Confirm';
 import CustomAlert from '@/components/common/Alert';
-import { FiBell } from 'react-icons/fi';
 import axiosInstance from '@/utils/axios';
 import handleApiError from '@/utils/handleApiError';
-import NotificationModal from './NotificationModal';
-import useNotification from '@/hooks/useNotification';
 import useWebSocket from '@/hooks/useWebSocket';
+import useNotification from '@/hooks/useNotification';
+import Logo from './Logo';
+import Navigation from './Navigation';
+import { NAVIGATION_ITEMS } from './constants';
 import { Notification } from '@/types/notification';
+import NotificationModal from './NotificationModal';
+import NotificationButton from './NotificationButton';
 
-type NavigationItem = {
-  path: string;
-  label: string;
-  id: string;
-};
-
-const NAVIGATION_ITEMS: NavigationItem[] = [
-  { path: '/community/study', label: '스터디', id: 'study' },
-  { path: '/community/info', label: '정보 공유', id: 'info' },
-  { path: '/community/qna', label: 'Q&A', id: 'qna' },
-  { path: '/community/ranking', label: '랭킹', id: 'ranking' },
-];
-
-const Logo = () => (
-  <Link
-    href="/"
-    className="btn btn-ghost text-base-content text-center overflow-hidden"
-  >
-    <div className="flex flex-col items-center">
-      <span className="block text-xs text-black">
-        스마트한 개발 스터디 플랫폼
-      </span>
-      <span className="block text-xl font-bold text-teal-500">
-        <Image
-          src={'/devonoff-logo.png'}
-          alt={'DevOnOff 로고'}
-          width={185}
-          height={185}
-          className="object-contain -mt-20"
-          priority
-        />
-      </span>
-    </div>
-  </Link>
-);
-
-const NotificationButton = ({
-  count,
-  onClick,
-  isActive,
-}: {
-  count: number;
-  onClick: () => void;
-  isActive: boolean;
-}) => (
-  <button
-    className={`btn btn-ghost relative ${isActive ? 'btn-active' : ''}`}
-    onClick={onClick}
-  >
-    <FiBell size={24} />
-    {count > 0 && (
-      <div className="absolute -top-1 -right-0.5 bg-customRed text-white rounded-full min-w-5 h-5 px-1 flex items-center justify-center text-xs">
-        {count > 99 ? '99+' : count}
-      </div>
-    )}
-  </button>
-);
-
-const Navigation = ({
-  items,
-  activeMenu,
-  onMenuClick,
-  className = '',
-  itemClassName = '',
-}: {
-  items: NavigationItem[];
+type AuthLinksProps = {
+  isSignedIn: boolean;
+  userInfo: any;
+  onSignOut: () => void;
   activeMenu: string;
   onMenuClick: (menu: string) => void;
   className?: string;
-  itemClassName?: string;
-}) => (
-  <nav className={className}>
-    {items.map(item => (
-      <Link
-        key={item.id}
-        href={item.path}
-        className={`btn ${itemClassName} ${activeMenu === item.id ? 'btn-active' : ''}`}
-        onClick={() => onMenuClick(item.id)}
-      >
-        {item.label}
-      </Link>
-    ))}
-  </nav>
-);
+  linkClassName?: string;
+};
+
+type MobileMenuProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
 
 const AuthLinks = ({
   isSignedIn,
@@ -109,15 +42,7 @@ const AuthLinks = ({
   onMenuClick,
   className = '',
   linkClassName = '',
-}: {
-  isSignedIn: boolean;
-  userInfo: any;
-  onSignOut: () => void;
-  activeMenu: string;
-  onMenuClick: (menu: string) => void;
-  className?: string;
-  linkClassName?: string;
-}) => (
+}: AuthLinksProps) => (
   <div className={className}>
     {isSignedIn ? (
       <>
@@ -145,15 +70,7 @@ const AuthLinks = ({
   </div>
 );
 
-const MobileMenu = ({
-  isOpen,
-  onClose,
-  children,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-  children: React.ReactNode;
-}) => {
+const MobileMenu = ({ isOpen, onClose, children }: MobileMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -224,13 +141,13 @@ const Header = () => {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
+    unreadCount,
   } = useNotification(userId || 0);
   const { connect, disconnect } = useWebSocket(userId || 0);
   const { notifications }: { notifications: Notification[] } = useNotification(
     userId || 0,
   );
   const [isNotificationModalOpen, setNotificationModalOpen] = useState(false);
-  const unreadCount = notifications.filter((n: Notification) => !n.read).length;
 
   const pathname = usePathname();
   const router = useRouter();

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -24,6 +24,7 @@ type AuthLinksProps = {
   onSignOut: () => void;
   activeMenu: string;
   onMenuClick: (menu: string) => void;
+  onClose?: () => void;
   className?: string;
   linkClassName?: string;
 };
@@ -40,6 +41,7 @@ const AuthLinks = ({
   onSignOut,
   activeMenu,
   onMenuClick,
+  onClose,
   className = '',
   linkClassName = '',
 }: AuthLinksProps) => (
@@ -59,10 +61,24 @@ const AuthLinks = ({
       </>
     ) : (
       <>
-        <Link href="/signin" className={`btn ${linkClassName}`}>
+        <Link
+          href="/signin"
+          className={`btn ${linkClassName}`}
+          onClick={() => {
+            onMenuClick('');
+            onClose?.();
+          }}
+        >
           로그인
         </Link>
-        <Link href="/signup" className={`btn ${linkClassName}`}>
+        <Link
+          href="/signup"
+          className={`btn ${linkClassName}`}
+          onClick={() => {
+            onMenuClick('');
+            onClose?.();
+          }}
+        >
           회원가입
         </Link>
       </>

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,5 @@
+export type NavigationItem = {
+  path: string;
+  label: string;
+  id: string;
+};


### PR DESCRIPTION
**AS-IS**
알림 개수 useQuery, invalidateQuries 사용하여 관리, 회원가입 성공 알림창 제대로 뜨도록 수정, 모바일 네비게이션바 자동 닫힘 수정


- 알림
  - 클라이언트 측에서 알림 개수 직접 계산 ➡️ page=0일 때의 알림 개수만 계산되고, 스크롤을 내려 다음 페이지 알림 api 요청을 해야 알림 개수가 정확히 계산되는 문제 발생
  - page=0에 해당하는 알림 데이터만 읽음/삭제 시 알림 내역 화면에서 회색처리/사라짐 처리가 적용되는 문제 발생
- 헤더 컴포넌트
  - 컴포넌트들을 헤더 컴포넌트 내에서 분리
- 회원가입
  - 회원가입 성공 시 알림창이 너무 빨리 사라져서 사용자가 회원가입을 성공했는지 확인하기 어려움
- 모바일 네비게이션바
  - 로그인, 회원가입 클릭 시 페이지 이동 후 네비게이션바가 닫히지 않음

**TO-BE**
- 알림
  - 알림 조회 시 알림 개수 api 요청도 함께 진행
  - 알림 캐시 업데이트 시 알림 개수 api 요청을 다시 진행하여 화면에 출력되는 개수 업데이트
  - useQuery로 알림 개수 관리하도록 수정
  - 알림 상태가 변경될 때 invalidateQueries를 사용하여 읽지 않은 알림 개수 관련 쿼리를 무효화하고 최신 데이터를 다시 가져오도록 수정
- 헤더 컴포넌트
  - 컴포넌트들을 각각의 파일로 분리
- 회원가입
  - 회원가입 성공 시 알림창이 뜨고, 확인 버튼 클릭 시 사라지도록 수정
- 모바일 네비게이션바
  - 로그인, 회원가입 클릭 시 페이지 이동 후 네비게이션바 자동으로 닫히도록 수정